### PR TITLE
feat(ui): render Plaud summaries as markdown and transcripts by speaker

### DIFF
--- a/src/components/dashboard/transcription-panel.tsx
+++ b/src/components/dashboard/transcription-panel.tsx
@@ -13,6 +13,10 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { TranscribeInBrowserButton } from "@/components/dashboard/transcribe-in-browser-button";
+import {
+    RichMarkdown,
+    SpeakerTranscript,
+} from "@/components/recordings/rich-content";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -184,10 +188,10 @@ export function TranscriptionPanel({
                                     ))}
                                 </div>
                             )}
-                            <div className="bg-muted rounded-lg p-4 max-h-96 overflow-y-auto">
-                                <p className="text-sm whitespace-pre-wrap leading-relaxed">
-                                    {activeTranscript.text}
-                                </p>
+                            <div className="bg-muted rounded-lg p-4 max-h-96 overflow-y-auto text-sm">
+                                <SpeakerTranscript
+                                    text={activeTranscript.text}
+                                />
                             </div>
                             <div className="flex items-center gap-4 text-xs text-muted-foreground pt-2 border-t">
                                 <span className="px-2 py-0.5 rounded bg-muted font-medium">
@@ -319,10 +323,10 @@ export function TranscriptionPanel({
                                 {summaryExpanded && (
                                     <div className="space-y-4">
                                         {/* Summary text */}
-                                        <div className="bg-muted rounded-lg p-4">
-                                            <p className="text-sm leading-relaxed">
-                                                {summaryData.summary}
-                                            </p>
+                                        <div className="bg-muted rounded-lg p-4 text-sm">
+                                            <RichMarkdown
+                                                content={summaryData.summary}
+                                            />
                                         </div>
 
                                         {/* Key points */}

--- a/src/components/recordings/rich-content.tsx
+++ b/src/components/recordings/rich-content.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import type { JSX, ReactNode } from "react";
+
+function isSafeImageSrc(src: string): boolean {
+    return src.startsWith("/api/plaud-assets/") || src.startsWith("https://");
+}
+
+// Inline markdown: bold, italic, inline code, strikethrough, and links.
+function renderInline(text: string, keyPrefix: string): ReactNode[] {
+    const nodes: ReactNode[] = [];
+    // Ordered so the first match at a position wins.
+    const pattern =
+        /(\*\*([^*]+)\*\*)|(~~([^~]+)~~)|(`([^`]+)`)|(\*([^*]+)\*)|(_([^_]+)_)|(\[([^\]]+)\]\(([^)]+)\))/g;
+    let last = 0;
+    let m: RegExpExecArray | null;
+    let i = 0;
+    // biome-ignore lint/suspicious/noAssignInExpressions: standard regex loop
+    while ((m = pattern.exec(text)) !== null) {
+        if (m.index > last) nodes.push(text.slice(last, m.index));
+        const k = `${keyPrefix}-i${i++}`;
+        if (m[1]) nodes.push(<strong key={k}>{m[2]}</strong>);
+        else if (m[3])
+            nodes.push(
+                <del key={k} className="opacity-70">
+                    {m[4]}
+                </del>,
+            );
+        else if (m[5])
+            nodes.push(
+                <code
+                    key={k}
+                    className="rounded bg-black/20 px-1 py-0.5 font-mono text-[0.85em]"
+                >
+                    {m[6]}
+                </code>,
+            );
+        else if (m[7]) nodes.push(<em key={k}>{m[8]}</em>);
+        else if (m[9]) nodes.push(<em key={k}>{m[10]}</em>);
+        else if (m[11]) {
+            const href = m[13];
+            const safe = href.startsWith("https://") || href.startsWith("/");
+            nodes.push(
+                safe ? (
+                    <a
+                        key={k}
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-accent-cyan underline underline-offset-2"
+                    >
+                        {m[12]}
+                    </a>
+                ) : (
+                    m[12]
+                ),
+            );
+        }
+        last = pattern.lastIndex;
+    }
+    if (last < text.length) nodes.push(text.slice(last));
+    return nodes;
+}
+
+const HR_RE = /^\s*([-*_])\1{2,}\s*$/; // ---, ***, ___ (3+)
+const IMG_RE = /^!\[([^\]]*)\]\(([^)]+)\)\s*$/;
+const HEADING_RE = /^(#{1,6})\s+(.*)$/;
+const BULLET_RE = /^\s*[-*]\s+(.*)$/;
+const CHECK_RE = /^\s*[-*]\s+\[([ xX])\]\s+(.*)$/;
+const ORDERED_RE = /^\s*\d+[.)]\s+(.*)$/;
+const QUOTE_RE = /^\s*>\s?(.*)$/;
+
+/**
+ * Render the markdown subset Plaud emits in summaries: headings, bold,
+ * italic, strikethrough, inline code, bullet/ordered/checkbox lists,
+ * blockquotes, horizontal rules, links, and images.
+ *
+ * Output is built from React elements, never `dangerouslySetInnerHTML`, so
+ * every text run is auto-escaped. Image sources are restricted to
+ * same-origin asset routes and `https:`, and link hrefs to `https:` and
+ * same-origin paths, so summary content cannot introduce a `data:` or
+ * `javascript:` URL. Anything unrecognised falls through as plain text.
+ */
+export function RichMarkdown({
+    content,
+    className,
+}: {
+    content: string;
+    className?: string;
+}): JSX.Element {
+    const lines = content.replace(/\r\n/g, "\n").split("\n");
+    const blocks: ReactNode[] = [];
+    let para: string[] = [];
+    let list: {
+        ordered: boolean;
+        items: { text: string; check?: boolean }[];
+    } | null = null;
+    let quote: string[] = [];
+    let b = 0;
+
+    const flushPara = () => {
+        if (para.length) {
+            const key = `p${b++}`;
+            blocks.push(
+                <p key={key} className="leading-relaxed my-2">
+                    {renderInline(para.join(" "), key)}
+                </p>,
+            );
+            para = [];
+        }
+    };
+    const flushList = () => {
+        if (list) {
+            const key = `l${b++}`;
+            const items = list.items.map((it, idx) => (
+                <li
+                    // biome-ignore lint/suspicious/noArrayIndexKey: parsed output is rebuilt from scratch on every render and never reordered
+                    key={`${key}-${idx}`}
+                    className="leading-relaxed flex gap-2 items-start"
+                >
+                    {it.check !== undefined && (
+                        <input
+                            type="checkbox"
+                            checked={it.check}
+                            readOnly
+                            className="mt-1.5 shrink-0 accent-accent-cyan"
+                        />
+                    )}
+                    {it.check === undefined && (
+                        <span className="mt-1.5 size-1.5 rounded-full bg-accent-cyan shrink-0" />
+                    )}
+                    <span>{renderInline(it.text, `${key}-${idx}`)}</span>
+                </li>
+            ));
+            blocks.push(
+                list.ordered ? (
+                    <ol key={key} className="my-2 space-y-1 list-decimal pl-5">
+                        {items}
+                    </ol>
+                ) : (
+                    <ul key={key} className="my-2 space-y-1">
+                        {items}
+                    </ul>
+                ),
+            );
+            list = null;
+        }
+    };
+    const flushQuote = () => {
+        if (quote.length) {
+            const key = `q${b++}`;
+            blocks.push(
+                <blockquote
+                    key={key}
+                    className="my-2 border-l-2 border-accent-cyan/60 pl-3 italic text-muted-foreground"
+                >
+                    {renderInline(quote.join(" "), key)}
+                </blockquote>,
+            );
+            quote = [];
+        }
+    };
+    const flushAll = () => {
+        flushPara();
+        flushList();
+        flushQuote();
+    };
+
+    for (const raw of lines) {
+        const line = raw.trimEnd();
+        if (!line.trim()) {
+            flushAll();
+            continue;
+        }
+
+        const img = line.match(IMG_RE);
+        if (img && isSafeImageSrc(img[2])) {
+            flushAll();
+            blocks.push(
+                // biome-ignore lint/performance/noImgElement: remote object-storage asset behind an auth-gated route, not a bundled static asset next/image can optimize
+                <img
+                    key={`img${b++}`}
+                    src={img[2]}
+                    alt={img[1] || "summary graphic"}
+                    className="my-3 max-w-full rounded-lg border border-border"
+                    loading="lazy"
+                />,
+            );
+            continue;
+        }
+
+        if (HR_RE.test(line)) {
+            flushAll();
+            blocks.push(<hr key={`hr${b++}`} className="my-4 border-border" />);
+            continue;
+        }
+
+        const h = line.match(HEADING_RE);
+        if (h) {
+            flushAll();
+            const level = Math.min(h[1].length, 6);
+            const key = `h${b++}`;
+            const inner = renderInline(h[2], key);
+            const cls: Record<number, string> = {
+                1: "text-xl font-bold mt-4 mb-2",
+                2: "text-lg font-semibold mt-4 mb-2",
+                3: "text-base font-semibold mt-3 mb-1",
+                4: "text-sm font-semibold mt-2 mb-1",
+                5: "text-sm font-medium mt-2 mb-1",
+                6: "text-xs font-medium uppercase tracking-wide mt-2 mb-1",
+            };
+            const c = cls[level];
+            blocks.push(
+                level === 1 ? (
+                    <h1 key={key} className={c}>
+                        {inner}
+                    </h1>
+                ) : level === 2 ? (
+                    <h2 key={key} className={c}>
+                        {inner}
+                    </h2>
+                ) : level === 3 ? (
+                    <h3 key={key} className={c}>
+                        {inner}
+                    </h3>
+                ) : level === 4 ? (
+                    <h4 key={key} className={c}>
+                        {inner}
+                    </h4>
+                ) : level === 5 ? (
+                    <h5 key={key} className={c}>
+                        {inner}
+                    </h5>
+                ) : (
+                    <h6 key={key} className={c}>
+                        {inner}
+                    </h6>
+                ),
+            );
+            continue;
+        }
+
+        const q = line.match(QUOTE_RE);
+        if (q) {
+            flushPara();
+            flushList();
+            quote.push(q[1]);
+            continue;
+        }
+        flushQuote();
+
+        const chk = line.match(CHECK_RE);
+        if (chk) {
+            flushPara();
+            if (!list || list.ordered) {
+                flushList();
+                list = { ordered: false, items: [] };
+            }
+            list.items.push({
+                text: chk[2],
+                check: chk[1].toLowerCase() === "x",
+            });
+            continue;
+        }
+        const bul = line.match(BULLET_RE);
+        if (bul) {
+            flushPara();
+            if (!list || list.ordered) {
+                flushList();
+                list = { ordered: false, items: [] };
+            }
+            list.items.push({ text: bul[1] });
+            continue;
+        }
+        const ord = line.match(ORDERED_RE);
+        if (ord) {
+            flushPara();
+            if (!list || !list.ordered) {
+                flushList();
+                list = { ordered: true, items: [] };
+            }
+            list.items.push({ text: ord[1] });
+            continue;
+        }
+
+        flushList();
+        para.push(line.trim());
+    }
+    flushAll();
+
+    return <div className={className}>{blocks}</div>;
+}
+
+const SPEAKER_RE = /^(Speaker\s+\w+|[A-Z][\w .'-]{0,40}):\s*(.*)$/;
+
+const SPEAKER_COLORS = [
+    "text-accent-cyan",
+    "text-emerald-400",
+    "text-amber-400",
+    "text-violet-400",
+    "text-rose-400",
+    "text-sky-400",
+];
+
+/**
+ * Render a diarized transcript as one block per speaker turn, colouring
+ * each speaker label consistently in order of first appearance.
+ *
+ * Plaud transcripts arrive as `SPEAKER_00: ...` / `Speaker 1: ...` lines,
+ * one turn per line. A line with no recognised label is appended to the
+ * preceding unlabelled turn. When no line carries a label at all (a plain
+ * Whisper transcript, for example) the whole text is rendered as
+ * pre-wrapped plain text, which is the previous behaviour.
+ */
+export function SpeakerTranscript({
+    text,
+    className,
+}: {
+    text: string;
+    className?: string;
+}): JSX.Element {
+    const lines = text
+        .replace(/\r\n/g, "\n")
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+
+    const turns: { speaker: string | null; text: string }[] = [];
+    for (const line of lines) {
+        const m = line.match(SPEAKER_RE);
+        if (m) turns.push({ speaker: m[1], text: m[2] });
+        else if (turns.length && turns[turns.length - 1].speaker === null)
+            turns[turns.length - 1].text += ` ${line}`;
+        else turns.push({ speaker: null, text: line });
+    }
+
+    const hasSpeakers = turns.some((t) => t.speaker !== null);
+    if (!hasSpeakers) {
+        return (
+            <p
+                className={`whitespace-pre-wrap leading-relaxed ${className ?? ""}`}
+            >
+                {text}
+            </p>
+        );
+    }
+
+    const order: string[] = [];
+    const colorFor = (speaker: string) => {
+        let idx = order.indexOf(speaker);
+        if (idx === -1) {
+            order.push(speaker);
+            idx = order.length - 1;
+        }
+        return SPEAKER_COLORS[idx % SPEAKER_COLORS.length];
+    };
+
+    return (
+        <div className={`space-y-3 ${className ?? ""}`}>
+            {turns.map((t, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: turns are reparsed from the transcript on every render and never reordered
+                <div key={`turn-${i}`} className="leading-relaxed">
+                    {t.speaker && (
+                        <span
+                            className={`font-semibold ${colorFor(t.speaker)} mr-2`}
+                        >
+                            {t.speaker}:
+                        </span>
+                    )}
+                    <span>{t.text}</span>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/recordings/rich-content.tsx
+++ b/src/components/recordings/rich-content.tsx
@@ -39,7 +39,14 @@ function renderInline(text: string, keyPrefix: string): ReactNode[] {
         else if (m[9]) nodes.push(<em key={k}>{m[10]}</em>);
         else if (m[11]) {
             const href = m[13];
-            const safe = href.startsWith("https://") || href.startsWith("/");
+            // Same-origin paths and https only. A leading "//" (or "/\") is
+            // protocol-relative and resolves to an EXTERNAL host, so it must not
+            // pass the "/" check.
+            const safe =
+                href.startsWith("https://") ||
+                (href.startsWith("/") &&
+                    !href.startsWith("//") &&
+                    !href.startsWith("/\\"));
             nodes.push(
                 safe ? (
                     <a
@@ -308,7 +315,12 @@ export function RichMarkdown({
     return <div className={className}>{blocks}</div>;
 }
 
-const SPEAKER_RE = /^(Speaker\s+\w+|[A-Z][\w .'-]{0,40}):\s*(.*)$/;
+// Only the diarization label formats this app actually emits — `SPEAKER_00`
+// (WhisperX), `Speaker 1` (Plaud), and the `UNKNOWN` fallback. A generic
+// `Capitalized:` pattern would misread an ordinary transcript line such as
+// `Question: ...` or `Action item: ...` as a speaker turn and wrongly switch a
+// non-diarized transcript out of its plain-text fallback.
+const SPEAKER_RE = /^(SPEAKER_\w+|Speaker\s+\w+|UNKNOWN):\s*(.*)$/;
 
 const SPEAKER_COLORS = [
     "text-accent-cyan",

--- a/src/components/recordings/rich-content.tsx
+++ b/src/components/recordings/rich-content.tsx
@@ -112,28 +112,45 @@ export function RichMarkdown({
     const flushList = () => {
         if (list) {
             const key = `l${b++}`;
-            const items = list.items.map((it, idx) => (
-                <li
-                    // biome-ignore lint/suspicious/noArrayIndexKey: parsed output is rebuilt from scratch on every render and never reordered
-                    key={`${key}-${idx}`}
-                    className="leading-relaxed flex gap-2 items-start"
-                >
-                    {it.check !== undefined && (
+            const ordered = list.ordered;
+            const items = list.items.map((it, idx) => {
+                // An ordered list keeps its native list-decimal marker, so it must NOT
+                // become a flex row and must not get a bullet injected - either would
+                // suppress the number. Only unordered rows use the flex + marker layout.
+                const marker =
+                    it.check !== undefined ? (
                         <input
                             type="checkbox"
                             checked={it.check}
                             readOnly
                             className="mt-1.5 shrink-0 accent-accent-cyan"
                         />
-                    )}
-                    {it.check === undefined && (
+                    ) : ordered ? null : (
                         <span className="mt-1.5 size-1.5 rounded-full bg-accent-cyan shrink-0" />
-                    )}
-                    <span>{renderInline(it.text, `${key}-${idx}`)}</span>
-                </li>
-            ));
+                    );
+                return (
+                    <li
+                        // biome-ignore lint/suspicious/noArrayIndexKey: parsed output is rebuilt from scratch on every render and never reordered
+                        key={`${key}-${idx}`}
+                        className={
+                            marker
+                                ? "leading-relaxed flex gap-2 items-start"
+                                : "leading-relaxed"
+                        }
+                    >
+                        {marker}
+                        {marker ? (
+                            <span>
+                                {renderInline(it.text, `${key}-${idx}`)}
+                            </span>
+                        ) : (
+                            renderInline(it.text, `${key}-${idx}`)
+                        )}
+                    </li>
+                );
+            });
             blocks.push(
-                list.ordered ? (
+                ordered ? (
                     <ol key={key} className="my-2 space-y-1 list-decimal pl-5">
                         {items}
                     </ol>

--- a/src/tests/regressions/265-rich-content.test.ts
+++ b/src/tests/regressions/265-rich-content.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Regression for #265: Plaud markdown summaries and SPEAKER-labeled
+ * transcript turns render as React trees in the transcription panel.
+ * Non-diarized text stays pre-wrapped; href/src stay on the allowlist.
+ */
+
+// @vitest-environment jsdom
+
+import { render } from "@testing-library/react";
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+import {
+    RichMarkdown,
+    SpeakerTranscript,
+} from "@/components/recordings/rich-content";
+
+describe("RichMarkdown (#265)", () => {
+    it("renders Plaud headings, emphasis, lists, quotes, and rules", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: [
+                    "# Meeting Summary",
+                    "",
+                    "This is **bold** and *italic* and ~~old~~ and `code`.",
+                    "",
+                    "- first",
+                    "- second",
+                    "",
+                    "1. alpha",
+                    "2. beta",
+                    "",
+                    "- [x] done",
+                    "- [ ] later",
+                    "",
+                    "> quoted",
+                    "",
+                    "---",
+                ].join("\n"),
+            }),
+        );
+
+        expect(container.querySelector("h1")?.textContent).toBe(
+            "Meeting Summary",
+        );
+        expect(container.querySelector("strong")?.textContent).toBe("bold");
+        expect(container.querySelector("em")?.textContent).toBe("italic");
+        expect(container.querySelector("del")?.textContent).toBe("old");
+        expect(container.querySelector("code")?.textContent).toBe("code");
+        expect(
+            [...container.querySelectorAll("ul > li")].map((li) =>
+                li.textContent?.trim(),
+            ),
+        ).toEqual(["first", "second", "done", "later"]);
+        const olItems = [...container.querySelectorAll("ol > li")];
+        expect(olItems.map((li) => li.textContent?.trim())).toEqual([
+            "alpha",
+            "beta",
+        ]);
+        expect(container.querySelector("ol")?.className).toContain(
+            "list-decimal",
+        );
+        for (const li of olItems) {
+            expect(li.className).not.toContain("flex");
+        }
+        expect(
+            container.querySelectorAll('input[type="checkbox"]'),
+        ).toHaveLength(2);
+        expect(
+            (
+                container.querySelector(
+                    'input[type="checkbox"]',
+                ) as HTMLInputElement
+            ).checked,
+        ).toBe(true);
+        expect(container.querySelector("blockquote")?.textContent).toBe(
+            "quoted",
+        );
+        expect(container.querySelector("hr")).not.toBeNull();
+    });
+
+    it("allowlists https and same-origin hrefs and rejects the rest", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: [
+                    "[ok](https://example.com/a)",
+                    "[path](/settings)",
+                    "[proto](//evil.example/x)",
+                    "[slash](/\\\\evil.example/x)",
+                    "[js](javascript:alert(1))",
+                    "[data](data:text/html,hi)",
+                    "[http](http://example.com/a)",
+                ].join("\n"),
+            }),
+        );
+
+        const hrefs = [...container.querySelectorAll("a")].map((a) =>
+            a.getAttribute("href"),
+        );
+        expect(hrefs).toEqual(["https://example.com/a", "/settings"]);
+        expect(container.textContent).toContain("proto");
+        expect(container.textContent).toContain("js");
+        expect(container.textContent).toContain("data");
+        expect(container.textContent).toContain("http");
+    });
+
+    it("allowlists image srcs and leaves unsafe images as text", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: [
+                    "![safe](https://cdn.example/img.png)",
+                    "![asset](/api/plaud-assets/x.png)",
+                    "![js](javascript:alert(1))",
+                    "![data](data:image/png;base64,aaaa)",
+                    "![proto](//evil.example/x.png)",
+                ].join("\n"),
+            }),
+        );
+
+        const srcs = [...container.querySelectorAll("img")].map((img) =>
+            img.getAttribute("src"),
+        );
+        expect(srcs).toEqual([
+            "https://cdn.example/img.png",
+            "/api/plaud-assets/x.png",
+        ]);
+        const hrefs = [...container.querySelectorAll("a")].map((a) =>
+            a.getAttribute("href"),
+        );
+        expect(hrefs).toEqual([]);
+        expect(srcs.some((src) => src?.startsWith("javascript:"))).toBe(false);
+        expect(srcs.some((src) => src?.startsWith("data:"))).toBe(false);
+        expect(srcs.some((src) => src?.startsWith("//"))).toBe(false);
+    });
+
+    it("escapes HTML instead of injecting it", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: '<script>alert("xss")</script>',
+            }),
+        );
+        expect(container.querySelector("script")).toBeNull();
+        expect(container.innerHTML).not.toContain("dangerouslySetInnerHTML");
+        expect(container.textContent).toContain(
+            '<script>alert("xss")</script>',
+        );
+    });
+});
+
+describe("SpeakerTranscript (#265)", () => {
+    it("groups SPEAKER, Speaker n, and UNKNOWN turns", () => {
+        const { container } = render(
+            createElement(SpeakerTranscript, {
+                text: [
+                    "SPEAKER_00: hello",
+                    "Speaker 1: there",
+                    "UNKNOWN: who",
+                    "SPEAKER_00: again",
+                ].join("\n"),
+            }),
+        );
+
+        const turns = [...container.querySelectorAll(":scope > div > div")];
+        expect(turns).toHaveLength(4);
+        expect(turns[0].querySelector("span")?.textContent).toBe("SPEAKER_00:");
+        expect(turns[1].querySelector("span")?.textContent).toBe("Speaker 1:");
+        expect(turns[2].querySelector("span")?.textContent).toBe("UNKNOWN:");
+        expect(turns[0].textContent).toContain("hello");
+        expect(turns[3].textContent).toContain("again");
+        expect(turns[0].querySelector("span")?.className).toContain(
+            "text-accent-cyan",
+        );
+        expect(turns[3].querySelector("span")?.className).toContain(
+            "text-accent-cyan",
+        );
+        expect(turns[1].querySelector("span")?.className).toContain(
+            "text-emerald-400",
+        );
+    });
+
+    it("keeps non-diarized transcripts pre-wrapped", () => {
+        const text = "Question: what now?\nAction item: ship it\nJust prose.";
+        const { container } = render(
+            createElement(SpeakerTranscript, { text }),
+        );
+        const p = container.querySelector("p");
+        expect(p).not.toBeNull();
+        expect(p?.className).toContain("whitespace-pre-wrap");
+        expect(p?.textContent).toBe(text);
+        expect(container.querySelectorAll(":scope > div > div")).toHaveLength(
+            0,
+        );
+    });
+});


### PR DESCRIPTION
Related: #230 (item 3, partially), #204.

## Why

Plaud stores summaries as markdown and transcripts as `SPEAKER_nn: ...` lines. The workstation renders both as a single raw text node:

```tsx
<p className="text-sm whitespace-pre-wrap leading-relaxed">
    {activeTranscript.text}
</p>
```

So on any recording synced from Plaud with a summary or a diarized transcript, the structure Plaud already produced is thrown away at render time. Headings, bold runs and bullet lists collapse into one paragraph, and every speaker turn runs into the next, so you cannot see who said what without reading the raw text. On a long meeting the summary is effectively unreadable.

## What this does

Adds `src/components/recordings/rich-content.tsx` with two renderers, and wires them into `transcription-panel.tsx` (three lines: one import, and the two `<p>` blocks swapped for the renderers).

**`RichMarkdown`** parses the subset Plaud actually emits: ATX headings, bold, italic, strikethrough, inline code, bullet / ordered / checkbox lists, blockquotes, horizontal rules, links, and images. Anything it does not recognise falls through as plain text rather than being dropped.

**`SpeakerTranscript`** groups the transcript into one block per turn and colours each speaker label consistently by order of first appearance. When no line carries a recognised label (a plain Whisper transcript, for example) it renders the text pre-wrapped exactly as it does today, so non-diarized transcripts are untouched.

## No new dependencies

The parser is a line scanner plus one inline regex, hand-written to cover the Plaud subset. No markdown library is added, so the client bundle does not grow and there is no new transitive dependency tree to audit. That was the main reason for writing it out rather than reaching for `react-markdown` plus a sanitizer.

## Injection surface

- Output is built from React elements, never `dangerouslySetInnerHTML`, so every text run is escaped by React.
- Image `src` is whitelisted to same-origin `/api/plaud-assets/` paths and `https:`.
- Link `href` is whitelisted to `https:` and same-origin paths; anything else renders as the link text with no anchor.

So summary content, which originates from a third-party API rather than from the user, cannot introduce a `data:` or `javascript:` URL.

## Relationship to #230

#230 item 3 asks for speaker-attributed blocks in the recording view. This is the render-time half of that, for transcripts whose text already carries labels: Plaud-native transcripts imported by #204, and `gpt-4o-transcribe-diarize` output, which `parseTranscriptionResponse` currently flattens to `Speaker: text` lines. It deliberately does **not** introduce the structured segment model #230 proposes. If you land `segments_json` later, `SpeakerTranscript` becomes a fallback for flat text rather than the primary path, and the summary renderer is unaffected either way. Flagging in case you would rather wait and do both together.

## Out of scope

- No changes to how summaries or transcripts are fetched, stored, or exported. This is render-time only. No schema change.
- Renaming speakers (#230 item 3, second half) is not included here.
- `transcription-panel.tsx` is also touched by #210. The overlap is small and in a different part of the file, but ordering may need a trivial rebase.
- No changes to `src/components/recordings/transcription-section.tsx`, which has its own summary layout. Happy to follow up there if you want the two unified.
- The `/api/plaud-assets/` prefix in the image whitelist is deliberately permissive of a route that does not exist on `main` yet. Nothing here depends on it: an `https:` image in a Plaud summary renders today, and an unmatched image line falls through as text.

## Testing

- `pnpm format-and-lint`, `pnpm type-check`, `pnpm test` (822 passed, 10 skipped), and `pnpm build` all pass on this branch.
- Running against real Plaud-synced recordings in a self-hosted deployment: markdown summaries with headings, bold, bullet and checkbox lists, and multi-speaker transcripts. Note that list nesting is flattened, not indented; Plaud does not appear to emit nested lists.
- No unit test is included. Both exports return React trees, and the vitest setup here is `environment: "node"` with no DOM or renderer available, so testing them would mean adding a test dependency. Say the word if you would rather have that and I will add it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders Plaud summaries as markdown and diarized transcripts as labeled, color-coded speaker turns instead of the previous single raw text blocks, making synced recordings readable in the transcription panel. Non-diarized transcripts keep their existing pre-wrapped plain-text rendering.

**Details**

- Adds a hand-written parser for Plaud headings, emphasis, lists, quotes, links, images, and horizontal rules without a markdown dependency.
- Restricts links and images to safe `https:` or same-origin URLs and builds output with escaped React elements.
- Keeps ordered-list markers intact and limits speaker detection to the formats this app emits.
- Addresses #265 and partially covers the render-time speaker blocks requested in #230.

**Testing**

- Adds jsdom regression tests for markdown rendering, URL allowlists, HTML escaping, speaker grouping, and plain-text fallback.

<sup>Written for commit 95392a8d744507973ead009880ddcee1f7fad00e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

