### PR TITLE
feat(speakers): name diarized speakers and match them across recordings

### DIFF
--- a/src/app/api/recordings/[id]/speakers/match/route.ts
+++ b/src/app/api/recordings/[id]/speakers/match/route.ts
@@ -1,0 +1,230 @@
+import { and, eq, ne } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { speakerNames, voiceProfiles } from "@/db/schema";
+import { requireApiSession } from "@/lib/auth-server";
+import { apiHandler } from "@/lib/errors";
+import {
+    cosineSimilarity,
+    isEmbedding,
+    parseEmbedding,
+    SPEAKER_MATCH_THRESHOLD,
+} from "@/lib/speakers/embeddings";
+import {
+    assertRecordingOwned,
+    MAX_SPEAKERS_PER_MATCH,
+    parseSpeakerLabel,
+    speakerInputError,
+} from "@/lib/speakers/request";
+import {
+    type SpeakerName,
+    serializeSpeakerName,
+    type VoiceProfileRow,
+} from "@/types/speaker";
+
+type IdContext = { params: Promise<{ id: string }> };
+
+interface SpeakerEmbedding {
+    speakerLabel: string;
+    embedding: number[];
+}
+
+interface UnmatchedSpeaker {
+    speakerLabel: string;
+    /** Closest profile name, or null when the user has no usable profiles. */
+    bestMatch: string | null;
+    bestScore: number | null;
+}
+
+interface SkippedSpeaker {
+    speakerLabel: string;
+    reason: "manual";
+    displayName: string;
+}
+
+function parseEmbeddingsPayload(value: unknown): SpeakerEmbedding[] {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error(
+            "embeddings must be an object keyed by speaker label, e.g. { SPEAKER_00: [...] }",
+        );
+    }
+
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) {
+        throw new Error("embeddings must contain at least one speaker");
+    }
+    if (entries.length > MAX_SPEAKERS_PER_MATCH) {
+        throw new Error(
+            `embeddings must contain at most ${MAX_SPEAKERS_PER_MATCH} speakers`,
+        );
+    }
+
+    const seen = new Set<string>();
+    return entries.map(([rawLabel, rawEmbedding]) => {
+        const speakerLabel = parseSpeakerLabel(rawLabel);
+        if (seen.has(speakerLabel)) {
+            throw new Error(`duplicate speaker label: ${speakerLabel}`);
+        }
+        seen.add(speakerLabel);
+        const field = `embeddings.${speakerLabel}`;
+        return {
+            speakerLabel,
+            embedding: parseEmbedding(rawEmbedding, field),
+        };
+    });
+}
+
+function round(value: number): number {
+    return Math.round(value * 10_000) / 10_000;
+}
+
+/**
+ * Match this recording's diarized speakers against the caller's voice
+ * profiles and auto-name the ones that clear
+ * `SPEAKER_MATCH_THRESHOLD`.
+ *
+ * Body: `{ embeddings: { SPEAKER_00: number[256], ... } }`.
+ *
+ * Rows the user named by hand (`source = 'manual'`) are reported under
+ * `skipped` and never rewritten: the point of a manual name is that it
+ * wins. Everything below the threshold is reported under `unmatched` with
+ * its closest profile so the caller can see near-misses without anything
+ * being written.
+ */
+export const POST = apiHandler<IdContext>(async (request, context) => {
+    const session = await requireApiSession(request);
+    const { id } = await (context as IdContext).params;
+
+    await assertRecordingOwned(id, session.user.id);
+
+    const body = (await request.json().catch(() => null)) as Record<
+        string,
+        unknown
+    > | null;
+
+    let inputs: SpeakerEmbedding[];
+    try {
+        inputs = parseEmbeddingsPayload(body?.embeddings);
+    } catch (error) {
+        throw speakerInputError(error);
+    }
+
+    const profiles = await db
+        .select()
+        .from(voiceProfiles)
+        .where(eq(voiceProfiles.userId, session.user.id));
+
+    // Skip profiles whose stored vector no longer validates instead of
+    // letting cosineSimilarity's zero fallback score them.
+    const comparable = profiles.filter((profile) =>
+        isEmbedding(profile.embedding),
+    );
+
+    const candidates = inputs.map((input) => {
+        let best: { profile: VoiceProfileRow; score: number } | null = null;
+        for (const profile of comparable) {
+            const score = cosineSimilarity(input.embedding, profile.embedding);
+            if (!best || score > best.score) best = { profile, score };
+        }
+        return { speakerLabel: input.speakerLabel, best };
+    });
+
+    const now = new Date();
+    const outcome = await db.transaction(async (tx) => {
+        const matched: SpeakerName[] = [];
+        const unmatched: UnmatchedSpeaker[] = [];
+        const skipped: SkippedSpeaker[] = [];
+
+        for (const { speakerLabel, best } of candidates) {
+            const [existing] = await tx
+                .select({
+                    id: speakerNames.id,
+                    source: speakerNames.source,
+                    displayName: speakerNames.displayName,
+                })
+                .from(speakerNames)
+                .where(
+                    and(
+                        eq(speakerNames.recordingId, id),
+                        eq(speakerNames.userId, session.user.id),
+                        eq(speakerNames.speakerLabel, speakerLabel),
+                    ),
+                )
+                .for("update")
+                .limit(1);
+
+            if (existing?.source === "manual") {
+                skipped.push({
+                    speakerLabel,
+                    reason: "manual",
+                    displayName: existing.displayName,
+                });
+                continue;
+            }
+
+            if (!best || best.score < SPEAKER_MATCH_THRESHOLD) {
+                unmatched.push({
+                    speakerLabel,
+                    bestMatch: best?.profile.displayName ?? null,
+                    bestScore: best ? round(best.score) : null,
+                });
+                continue;
+            }
+
+            const { profile, score } = best;
+            const values = {
+                displayName: profile.displayName,
+                voiceProfileId: profile.id,
+                source: "auto",
+                confidence: round(score),
+                updatedAt: now,
+            };
+
+            if (existing) {
+                // The `source <> 'manual'` predicate repeats the check
+                // above at the write itself, so the row cannot be
+                // clobbered by a rename that lands mid-transaction.
+                const [row] = await tx
+                    .update(speakerNames)
+                    .set(values)
+                    .where(
+                        and(
+                            eq(speakerNames.id, existing.id),
+                            eq(speakerNames.userId, session.user.id),
+                            ne(speakerNames.source, "manual"),
+                        ),
+                    )
+                    .returning();
+                if (row) {
+                    matched.push(serializeSpeakerName(row));
+                } else {
+                    skipped.push({
+                        speakerLabel,
+                        reason: "manual",
+                        displayName: existing.displayName,
+                    });
+                }
+                continue;
+            }
+
+            const [row] = await tx
+                .insert(speakerNames)
+                .values({
+                    ...values,
+                    userId: session.user.id,
+                    recordingId: id,
+                    speakerLabel,
+                })
+                .returning();
+            matched.push(serializeSpeakerName(row));
+        }
+
+        return { matched, unmatched, skipped };
+    });
+
+    return NextResponse.json({
+        threshold: SPEAKER_MATCH_THRESHOLD,
+        profilesCompared: comparable.length,
+        ...outcome,
+    });
+});

--- a/src/app/api/recordings/[id]/speakers/match/route.ts
+++ b/src/app/api/recordings/[id]/speakers/match/route.ts
@@ -11,6 +11,10 @@ import {
     SPEAKER_MATCH_THRESHOLD,
 } from "@/lib/speakers/embeddings";
 import {
+    classifyConflictSpeaker,
+    isUniqueViolation,
+} from "@/lib/speakers/match-write";
+import {
     assertRecordingOwned,
     MAX_SPEAKERS_PER_MATCH,
     parseSpeakerLabel,
@@ -18,6 +22,7 @@ import {
 } from "@/lib/speakers/request";
 import {
     type SpeakerName,
+    type SpeakerNameRow,
     serializeSpeakerName,
     type VoiceProfileRow,
 } from "@/types/speaker";
@@ -207,16 +212,93 @@ export const POST = apiHandler<IdContext>(async (request, context) => {
                 continue;
             }
 
-            const [row] = await tx
-                .insert(speakerNames)
-                .values({
-                    ...values,
-                    userId: session.user.id,
-                    recordingId: id,
-                    speakerLabel,
+            let inserted: SpeakerNameRow[] | undefined;
+            try {
+                inserted = await tx.transaction(async (inner) => {
+                    return inner
+                        .insert(speakerNames)
+                        .values({
+                            ...values,
+                            userId: session.user.id,
+                            recordingId: id,
+                            speakerLabel,
+                        })
+                        .onConflictDoUpdate({
+                            target: [
+                                speakerNames.recordingId,
+                                speakerNames.speakerLabel,
+                            ],
+                            set: values,
+                            setWhere: ne(speakerNames.source, "manual"),
+                        })
+                        .returning();
+                });
+            } catch (error) {
+                if (!isUniqueViolation(error)) throw error;
+            }
+
+            const [row] = inserted ?? [];
+            if (row) {
+                matched.push(serializeSpeakerName(row));
+                continue;
+            }
+
+            const [created] = await tx
+                .select({
+                    id: speakerNames.id,
+                    source: speakerNames.source,
+                    displayName: speakerNames.displayName,
                 })
-                .returning();
-            matched.push(serializeSpeakerName(row));
+                .from(speakerNames)
+                .where(
+                    and(
+                        eq(speakerNames.recordingId, id),
+                        eq(speakerNames.userId, session.user.id),
+                        eq(speakerNames.speakerLabel, speakerLabel),
+                    ),
+                )
+                .for("update")
+                .limit(1);
+
+            const conflict = classifyConflictSpeaker(created);
+            switch (conflict.action) {
+                case "skip":
+                    skipped.push({
+                        speakerLabel,
+                        reason: "manual",
+                        displayName: conflict.displayName,
+                    });
+                    break;
+                case "update": {
+                    const [updated] = await tx
+                        .update(speakerNames)
+                        .set(values)
+                        .where(
+                            and(
+                                eq(speakerNames.id, conflict.id),
+                                eq(speakerNames.userId, session.user.id),
+                                ne(speakerNames.source, "manual"),
+                            ),
+                        )
+                        .returning();
+                    if (updated) {
+                        matched.push(serializeSpeakerName(updated));
+                    } else {
+                        skipped.push({
+                            speakerLabel,
+                            reason: "manual",
+                            displayName: conflict.displayName,
+                        });
+                    }
+                    break;
+                }
+                case "none":
+                    break;
+                default: {
+                    const _exhaustive: never = conflict;
+                    void _exhaustive;
+                }
+            }
         }
 
         return { matched, unmatched, skipped };

--- a/src/app/api/recordings/[id]/speakers/route.ts
+++ b/src/app/api/recordings/[id]/speakers/route.ts
@@ -1,0 +1,130 @@
+import { and, asc, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { speakerNames } from "@/db/schema";
+import { requireApiSession } from "@/lib/auth-server";
+import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import {
+    assertRecordingOwned,
+    parseDisplayName,
+    parseSpeakerLabel,
+    speakerInputError,
+} from "@/lib/speakers/request";
+import { serializeSpeakerName } from "@/types/speaker";
+
+type IdContext = { params: Promise<{ id: string }> };
+
+/** List the human names set for this recording's diarized speakers. */
+export const GET = apiHandler<IdContext>(async (request, context) => {
+    const session = await requireApiSession(request);
+    const { id } = await (context as IdContext).params;
+
+    await assertRecordingOwned(id, session.user.id);
+
+    const rows = await db
+        .select()
+        .from(speakerNames)
+        .where(
+            and(
+                eq(speakerNames.recordingId, id),
+                eq(speakerNames.userId, session.user.id),
+            ),
+        )
+        .orderBy(asc(speakerNames.speakerLabel));
+
+    return NextResponse.json({ speakers: rows.map(serializeSpeakerName) });
+});
+
+/**
+ * Name one speaker by hand.
+ *
+ * Body: `{ speakerLabel, displayName }`.
+ *
+ * Always writes `source = 'manual'` and clears `confidence` /
+ * `voiceProfileId`: a hand-typed name supersedes whatever the voice
+ * matcher decided, and the match route will not touch the row again.
+ */
+export const PUT = apiHandler<IdContext>(async (request, context) => {
+    const session = await requireApiSession(request);
+    const { id } = await (context as IdContext).params;
+
+    await assertRecordingOwned(id, session.user.id);
+
+    const body = (await request.json().catch(() => null)) as Record<
+        string,
+        unknown
+    > | null;
+
+    let speakerLabel: string;
+    let displayName: string;
+    try {
+        speakerLabel = parseSpeakerLabel(body?.speakerLabel);
+        displayName = parseDisplayName(body?.displayName);
+    } catch (error) {
+        throw speakerInputError(error);
+    }
+
+    const now = new Date();
+    const [row] = await db
+        .insert(speakerNames)
+        .values({
+            userId: session.user.id,
+            recordingId: id,
+            speakerLabel,
+            displayName,
+            source: "manual",
+            confidence: null,
+            voiceProfileId: null,
+            updatedAt: now,
+        })
+        .onConflictDoUpdate({
+            target: [speakerNames.recordingId, speakerNames.speakerLabel],
+            set: {
+                // userId is re-asserted so a row that somehow carries the
+                // wrong owner self-heals to the verified recording owner.
+                userId: session.user.id,
+                displayName,
+                source: "manual",
+                confidence: null,
+                voiceProfileId: null,
+                updatedAt: now,
+            },
+        })
+        .returning();
+
+    return NextResponse.json({ speaker: serializeSpeakerName(row) });
+});
+
+/**
+ * Clear one speaker's name via `?label=SPEAKER_00`, dropping it back to
+ * the raw diarization label. Idempotent: removing a name that is not set
+ * returns `{ deleted: false }` rather than a 404.
+ */
+export const DELETE = apiHandler<IdContext>(async (request, context) => {
+    const session = await requireApiSession(request);
+    const { id } = await (context as IdContext).params;
+
+    await assertRecordingOwned(id, session.user.id);
+
+    const label = new URL(request.url).searchParams.get("label");
+    if (!label?.trim()) {
+        throw new AppError(
+            ErrorCode.MISSING_REQUIRED_FIELD,
+            "Query parameter 'label' is required",
+            400,
+        );
+    }
+
+    const deleted = await db
+        .delete(speakerNames)
+        .where(
+            and(
+                eq(speakerNames.recordingId, id),
+                eq(speakerNames.userId, session.user.id),
+                eq(speakerNames.speakerLabel, label.trim()),
+            ),
+        )
+        .returning({ id: speakerNames.id });
+
+    return NextResponse.json({ deleted: deleted.length > 0 });
+});

--- a/src/app/api/voice-profiles/route.ts
+++ b/src/app/api/voice-profiles/route.ts
@@ -1,0 +1,117 @@
+import { and, asc, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { voiceProfiles } from "@/db/schema";
+import { requireApiSession } from "@/lib/auth-server";
+import { apiHandler } from "@/lib/errors";
+import {
+    isEmbedding,
+    mergeCentroid,
+    parseEmbedding,
+    toStoredEmbedding,
+} from "@/lib/speakers/embeddings";
+import { parseDisplayName, speakerInputError } from "@/lib/speakers/request";
+import { serializeVoiceProfile } from "@/types/speaker";
+
+/**
+ * List the caller's known voices. Embeddings are deliberately omitted:
+ * they are several KB each and no client needs them, matching is
+ * server-side.
+ */
+export const GET = apiHandler(async (request: Request) => {
+    const session = await requireApiSession(request);
+
+    const rows = await db
+        .select({
+            id: voiceProfiles.id,
+            displayName: voiceProfiles.displayName,
+            sampleCount: voiceProfiles.sampleCount,
+            createdAt: voiceProfiles.createdAt,
+            updatedAt: voiceProfiles.updatedAt,
+        })
+        .from(voiceProfiles)
+        .where(eq(voiceProfiles.userId, session.user.id))
+        .orderBy(asc(voiceProfiles.displayName));
+
+    return NextResponse.json({ profiles: rows.map(serializeVoiceProfile) });
+});
+
+/**
+ * Create or extend a voice profile.
+ *
+ * Body: `{ displayName, embedding: number[256] }`.
+ *
+ * `displayName` is the identity: an unknown name creates a profile (201),
+ * a known one folds the sample into the running centroid and bumps
+ * `sampleCount` (200). The read and the write share one transaction with
+ * the row locked, so two concurrent samples for the same person cannot
+ * both merge against the same pre-state and lose one of the two.
+ */
+export const POST = apiHandler(async (request: Request) => {
+    const session = await requireApiSession(request);
+
+    const body = (await request.json().catch(() => null)) as Record<
+        string,
+        unknown
+    > | null;
+
+    let displayName: string;
+    let embedding: number[];
+    try {
+        displayName = parseDisplayName(body?.displayName);
+        embedding = parseEmbedding(body?.embedding);
+    } catch (error) {
+        throw speakerInputError(error);
+    }
+
+    const result = await db.transaction(async (tx) => {
+        const [existing] = await tx
+            .select()
+            .from(voiceProfiles)
+            .where(
+                and(
+                    eq(voiceProfiles.userId, session.user.id),
+                    eq(voiceProfiles.displayName, displayName),
+                ),
+            )
+            .for("update")
+            .limit(1);
+
+        if (!existing) {
+            const [created] = await tx
+                .insert(voiceProfiles)
+                .values({
+                    userId: session.user.id,
+                    displayName,
+                    embedding: toStoredEmbedding(embedding),
+                    sampleCount: 1,
+                })
+                .returning();
+            return { profile: created, created: true };
+        }
+
+        // A stored vector that no longer validates (hand-edited row,
+        // dimension change upstream) is replaced rather than merged into,
+        // so one bad row cannot poison every future match.
+        const storedIsUsable = isEmbedding(existing.embedding);
+        const nextEmbedding = storedIsUsable
+            ? mergeCentroid(existing.embedding, existing.sampleCount, embedding)
+            : toStoredEmbedding(embedding);
+
+        const [updated] = await tx
+            .update(voiceProfiles)
+            .set({
+                embedding: nextEmbedding,
+                sampleCount: storedIsUsable ? existing.sampleCount + 1 : 1,
+                updatedAt: new Date(),
+            })
+            .where(eq(voiceProfiles.id, existing.id))
+            .returning();
+        return { profile: updated, created: false };
+    });
+
+    return NextResponse.json(
+        { profile: serializeVoiceProfile(result.profile) },
+        { status: result.created ? 201 : 200 },
+    );
+});

--- a/src/components/dashboard/transcription-panel.tsx
+++ b/src/components/dashboard/transcription-panel.tsx
@@ -13,6 +13,10 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { TranscribeInBrowserButton } from "@/components/dashboard/transcribe-in-browser-button";
+import {
+    RichMarkdown,
+    SpeakerTranscript,
+} from "@/components/recordings/rich-content";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -184,10 +188,10 @@ export function TranscriptionPanel({
                                     ))}
                                 </div>
                             )}
-                            <div className="bg-muted rounded-lg p-4 max-h-96 overflow-y-auto">
-                                <p className="text-sm whitespace-pre-wrap leading-relaxed">
-                                    {activeTranscript.text}
-                                </p>
+                            <div className="bg-muted rounded-lg p-4 max-h-96 overflow-y-auto text-sm">
+                                <SpeakerTranscript
+                                    text={activeTranscript.text}
+                                />
                             </div>
                             <div className="flex items-center gap-4 text-xs text-muted-foreground pt-2 border-t">
                                 <span className="px-2 py-0.5 rounded bg-muted font-medium">
@@ -319,10 +323,10 @@ export function TranscriptionPanel({
                                 {summaryExpanded && (
                                     <div className="space-y-4">
                                         {/* Summary text */}
-                                        <div className="bg-muted rounded-lg p-4">
-                                            <p className="text-sm leading-relaxed">
-                                                {summaryData.summary}
-                                            </p>
+                                        <div className="bg-muted rounded-lg p-4 text-sm">
+                                            <RichMarkdown
+                                                content={summaryData.summary}
+                                            />
                                         </div>
 
                                         {/* Key points */}

--- a/src/components/dashboard/transcription-panel.tsx
+++ b/src/components/dashboard/transcription-panel.tsx
@@ -26,6 +26,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { useSpeakerNames } from "@/hooks/use-speaker-names";
 import { useTranscriptionSummary } from "@/hooks/use-transcription-summary";
 import type { Recording } from "@/types/recording";
 
@@ -104,6 +105,10 @@ export function TranscriptionPanel({
         recordingId: recording?.id,
         transcriptionText: activeTranscript?.text,
     });
+
+    // Speaker names are per-recording, not per transcript source: the
+    // diarization labels are the same whichever transcript is showing.
+    const { speakerNames, renameSpeaker } = useSpeakerNames(recording?.id);
 
     return (
         <div className="space-y-4">
@@ -191,6 +196,8 @@ export function TranscriptionPanel({
                             <div className="bg-muted rounded-lg p-4 max-h-96 overflow-y-auto text-sm">
                                 <SpeakerTranscript
                                     text={activeTranscript.text}
+                                    speakerNames={speakerNames}
+                                    onRenameSpeaker={renameSpeaker}
                                 />
                             </div>
                             <div className="flex items-center gap-4 text-xs text-muted-foreground pt-2 border-t">

--- a/src/components/recordings/rich-content.tsx
+++ b/src/components/recordings/rich-content.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import type { JSX, ReactNode } from "react";
+
+function isSafeImageSrc(src: string): boolean {
+    return src.startsWith("/api/plaud-assets/") || src.startsWith("https://");
+}
+
+// Inline markdown: bold, italic, inline code, strikethrough, and links.
+function renderInline(text: string, keyPrefix: string): ReactNode[] {
+    const nodes: ReactNode[] = [];
+    // Ordered so the first match at a position wins.
+    const pattern =
+        /(\*\*([^*]+)\*\*)|(~~([^~]+)~~)|(`([^`]+)`)|(\*([^*]+)\*)|(_([^_]+)_)|(\[([^\]]+)\]\(([^)]+)\))/g;
+    let last = 0;
+    let m: RegExpExecArray | null;
+    let i = 0;
+    // biome-ignore lint/suspicious/noAssignInExpressions: standard regex loop
+    while ((m = pattern.exec(text)) !== null) {
+        if (m.index > last) nodes.push(text.slice(last, m.index));
+        const k = `${keyPrefix}-i${i++}`;
+        if (m[1]) nodes.push(<strong key={k}>{m[2]}</strong>);
+        else if (m[3])
+            nodes.push(
+                <del key={k} className="opacity-70">
+                    {m[4]}
+                </del>,
+            );
+        else if (m[5])
+            nodes.push(
+                <code
+                    key={k}
+                    className="rounded bg-black/20 px-1 py-0.5 font-mono text-[0.85em]"
+                >
+                    {m[6]}
+                </code>,
+            );
+        else if (m[7]) nodes.push(<em key={k}>{m[8]}</em>);
+        else if (m[9]) nodes.push(<em key={k}>{m[10]}</em>);
+        else if (m[11]) {
+            const href = m[13];
+            const safe = href.startsWith("https://") || href.startsWith("/");
+            nodes.push(
+                safe ? (
+                    <a
+                        key={k}
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-accent-cyan underline underline-offset-2"
+                    >
+                        {m[12]}
+                    </a>
+                ) : (
+                    m[12]
+                ),
+            );
+        }
+        last = pattern.lastIndex;
+    }
+    if (last < text.length) nodes.push(text.slice(last));
+    return nodes;
+}
+
+const HR_RE = /^\s*([-*_])\1{2,}\s*$/; // ---, ***, ___ (3+)
+const IMG_RE = /^!\[([^\]]*)\]\(([^)]+)\)\s*$/;
+const HEADING_RE = /^(#{1,6})\s+(.*)$/;
+const BULLET_RE = /^\s*[-*]\s+(.*)$/;
+const CHECK_RE = /^\s*[-*]\s+\[([ xX])\]\s+(.*)$/;
+const ORDERED_RE = /^\s*\d+[.)]\s+(.*)$/;
+const QUOTE_RE = /^\s*>\s?(.*)$/;
+
+/**
+ * Render the markdown subset Plaud emits in summaries: headings, bold,
+ * italic, strikethrough, inline code, bullet/ordered/checkbox lists,
+ * blockquotes, horizontal rules, links, and images.
+ *
+ * Output is built from React elements, never `dangerouslySetInnerHTML`, so
+ * every text run is auto-escaped. Image sources are restricted to
+ * same-origin asset routes and `https:`, and link hrefs to `https:` and
+ * same-origin paths, so summary content cannot introduce a `data:` or
+ * `javascript:` URL. Anything unrecognised falls through as plain text.
+ */
+export function RichMarkdown({
+    content,
+    className,
+}: {
+    content: string;
+    className?: string;
+}): JSX.Element {
+    const lines = content.replace(/\r\n/g, "\n").split("\n");
+    const blocks: ReactNode[] = [];
+    let para: string[] = [];
+    let list: {
+        ordered: boolean;
+        items: { text: string; check?: boolean }[];
+    } | null = null;
+    let quote: string[] = [];
+    let b = 0;
+
+    const flushPara = () => {
+        if (para.length) {
+            const key = `p${b++}`;
+            blocks.push(
+                <p key={key} className="leading-relaxed my-2">
+                    {renderInline(para.join(" "), key)}
+                </p>,
+            );
+            para = [];
+        }
+    };
+    const flushList = () => {
+        if (list) {
+            const key = `l${b++}`;
+            const items = list.items.map((it, idx) => (
+                <li
+                    // biome-ignore lint/suspicious/noArrayIndexKey: parsed output is rebuilt from scratch on every render and never reordered
+                    key={`${key}-${idx}`}
+                    className="leading-relaxed flex gap-2 items-start"
+                >
+                    {it.check !== undefined && (
+                        <input
+                            type="checkbox"
+                            checked={it.check}
+                            readOnly
+                            className="mt-1.5 shrink-0 accent-accent-cyan"
+                        />
+                    )}
+                    {it.check === undefined && (
+                        <span className="mt-1.5 size-1.5 rounded-full bg-accent-cyan shrink-0" />
+                    )}
+                    <span>{renderInline(it.text, `${key}-${idx}`)}</span>
+                </li>
+            ));
+            blocks.push(
+                list.ordered ? (
+                    <ol key={key} className="my-2 space-y-1 list-decimal pl-5">
+                        {items}
+                    </ol>
+                ) : (
+                    <ul key={key} className="my-2 space-y-1">
+                        {items}
+                    </ul>
+                ),
+            );
+            list = null;
+        }
+    };
+    const flushQuote = () => {
+        if (quote.length) {
+            const key = `q${b++}`;
+            blocks.push(
+                <blockquote
+                    key={key}
+                    className="my-2 border-l-2 border-accent-cyan/60 pl-3 italic text-muted-foreground"
+                >
+                    {renderInline(quote.join(" "), key)}
+                </blockquote>,
+            );
+            quote = [];
+        }
+    };
+    const flushAll = () => {
+        flushPara();
+        flushList();
+        flushQuote();
+    };
+
+    for (const raw of lines) {
+        const line = raw.trimEnd();
+        if (!line.trim()) {
+            flushAll();
+            continue;
+        }
+
+        const img = line.match(IMG_RE);
+        if (img && isSafeImageSrc(img[2])) {
+            flushAll();
+            blocks.push(
+                // biome-ignore lint/performance/noImgElement: remote object-storage asset behind an auth-gated route, not a bundled static asset next/image can optimize
+                <img
+                    key={`img${b++}`}
+                    src={img[2]}
+                    alt={img[1] || "summary graphic"}
+                    className="my-3 max-w-full rounded-lg border border-border"
+                    loading="lazy"
+                />,
+            );
+            continue;
+        }
+
+        if (HR_RE.test(line)) {
+            flushAll();
+            blocks.push(<hr key={`hr${b++}`} className="my-4 border-border" />);
+            continue;
+        }
+
+        const h = line.match(HEADING_RE);
+        if (h) {
+            flushAll();
+            const level = Math.min(h[1].length, 6);
+            const key = `h${b++}`;
+            const inner = renderInline(h[2], key);
+            const cls: Record<number, string> = {
+                1: "text-xl font-bold mt-4 mb-2",
+                2: "text-lg font-semibold mt-4 mb-2",
+                3: "text-base font-semibold mt-3 mb-1",
+                4: "text-sm font-semibold mt-2 mb-1",
+                5: "text-sm font-medium mt-2 mb-1",
+                6: "text-xs font-medium uppercase tracking-wide mt-2 mb-1",
+            };
+            const c = cls[level];
+            blocks.push(
+                level === 1 ? (
+                    <h1 key={key} className={c}>
+                        {inner}
+                    </h1>
+                ) : level === 2 ? (
+                    <h2 key={key} className={c}>
+                        {inner}
+                    </h2>
+                ) : level === 3 ? (
+                    <h3 key={key} className={c}>
+                        {inner}
+                    </h3>
+                ) : level === 4 ? (
+                    <h4 key={key} className={c}>
+                        {inner}
+                    </h4>
+                ) : level === 5 ? (
+                    <h5 key={key} className={c}>
+                        {inner}
+                    </h5>
+                ) : (
+                    <h6 key={key} className={c}>
+                        {inner}
+                    </h6>
+                ),
+            );
+            continue;
+        }
+
+        const q = line.match(QUOTE_RE);
+        if (q) {
+            flushPara();
+            flushList();
+            quote.push(q[1]);
+            continue;
+        }
+        flushQuote();
+
+        const chk = line.match(CHECK_RE);
+        if (chk) {
+            flushPara();
+            if (!list || list.ordered) {
+                flushList();
+                list = { ordered: false, items: [] };
+            }
+            list.items.push({
+                text: chk[2],
+                check: chk[1].toLowerCase() === "x",
+            });
+            continue;
+        }
+        const bul = line.match(BULLET_RE);
+        if (bul) {
+            flushPara();
+            if (!list || list.ordered) {
+                flushList();
+                list = { ordered: false, items: [] };
+            }
+            list.items.push({ text: bul[1] });
+            continue;
+        }
+        const ord = line.match(ORDERED_RE);
+        if (ord) {
+            flushPara();
+            if (!list || !list.ordered) {
+                flushList();
+                list = { ordered: true, items: [] };
+            }
+            list.items.push({ text: ord[1] });
+            continue;
+        }
+
+        flushList();
+        para.push(line.trim());
+    }
+    flushAll();
+
+    return <div className={className}>{blocks}</div>;
+}
+
+const SPEAKER_RE = /^(Speaker\s+\w+|[A-Z][\w .'-]{0,40}):\s*(.*)$/;
+
+const SPEAKER_COLORS = [
+    "text-accent-cyan",
+    "text-emerald-400",
+    "text-amber-400",
+    "text-violet-400",
+    "text-rose-400",
+    "text-sky-400",
+];
+
+/**
+ * Render a diarized transcript as one block per speaker turn, colouring
+ * each speaker label consistently in order of first appearance.
+ *
+ * Plaud transcripts arrive as `SPEAKER_00: ...` / `Speaker 1: ...` lines,
+ * one turn per line. A line with no recognised label is appended to the
+ * preceding unlabelled turn. When no line carries a label at all (a plain
+ * Whisper transcript, for example) the whole text is rendered as
+ * pre-wrapped plain text, which is the previous behaviour.
+ */
+export function SpeakerTranscript({
+    text,
+    className,
+}: {
+    text: string;
+    className?: string;
+}): JSX.Element {
+    const lines = text
+        .replace(/\r\n/g, "\n")
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+
+    const turns: { speaker: string | null; text: string }[] = [];
+    for (const line of lines) {
+        const m = line.match(SPEAKER_RE);
+        if (m) turns.push({ speaker: m[1], text: m[2] });
+        else if (turns.length && turns[turns.length - 1].speaker === null)
+            turns[turns.length - 1].text += ` ${line}`;
+        else turns.push({ speaker: null, text: line });
+    }
+
+    const hasSpeakers = turns.some((t) => t.speaker !== null);
+    if (!hasSpeakers) {
+        return (
+            <p
+                className={`whitespace-pre-wrap leading-relaxed ${className ?? ""}`}
+            >
+                {text}
+            </p>
+        );
+    }
+
+    const order: string[] = [];
+    const colorFor = (speaker: string) => {
+        let idx = order.indexOf(speaker);
+        if (idx === -1) {
+            order.push(speaker);
+            idx = order.length - 1;
+        }
+        return SPEAKER_COLORS[idx % SPEAKER_COLORS.length];
+    };
+
+    return (
+        <div className={`space-y-3 ${className ?? ""}`}>
+            {turns.map((t, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: turns are reparsed from the transcript on every render and never reordered
+                <div key={`turn-${i}`} className="leading-relaxed">
+                    {t.speaker && (
+                        <span
+                            className={`font-semibold ${colorFor(t.speaker)} mr-2`}
+                        >
+                            {t.speaker}:
+                        </span>
+                    )}
+                    <span>{t.text}</span>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/recordings/rich-content.tsx
+++ b/src/components/recordings/rich-content.tsx
@@ -39,7 +39,14 @@ function renderInline(text: string, keyPrefix: string): ReactNode[] {
         else if (m[9]) nodes.push(<em key={k}>{m[10]}</em>);
         else if (m[11]) {
             const href = m[13];
-            const safe = href.startsWith("https://") || href.startsWith("/");
+            // Same-origin paths and https only. A leading "//" (or "/\") is
+            // protocol-relative and resolves to an EXTERNAL host, so it must not
+            // pass the "/" check.
+            const safe =
+                href.startsWith("https://") ||
+                (href.startsWith("/") &&
+                    !href.startsWith("//") &&
+                    !href.startsWith("/\\"));
             nodes.push(
                 safe ? (
                     <a
@@ -308,7 +315,12 @@ export function RichMarkdown({
     return <div className={className}>{blocks}</div>;
 }
 
-const SPEAKER_RE = /^(Speaker\s+\w+|[A-Z][\w .'-]{0,40}):\s*(.*)$/;
+// Only the diarization label formats this app actually emits — `SPEAKER_00`
+// (WhisperX), `Speaker 1` (Plaud), and the `UNKNOWN` fallback. A generic
+// `Capitalized:` pattern would misread an ordinary transcript line such as
+// `Question: ...` or `Action item: ...` as a speaker turn and wrongly switch a
+// non-diarized transcript out of its plain-text fallback.
+const SPEAKER_RE = /^(SPEAKER_\w+|Speaker\s+\w+|UNKNOWN):\s*(.*)$/;
 
 const SPEAKER_COLORS = [
     "text-accent-cyan",

--- a/src/components/recordings/rich-content.tsx
+++ b/src/components/recordings/rich-content.tsx
@@ -112,28 +112,45 @@ export function RichMarkdown({
     const flushList = () => {
         if (list) {
             const key = `l${b++}`;
-            const items = list.items.map((it, idx) => (
-                <li
-                    // biome-ignore lint/suspicious/noArrayIndexKey: parsed output is rebuilt from scratch on every render and never reordered
-                    key={`${key}-${idx}`}
-                    className="leading-relaxed flex gap-2 items-start"
-                >
-                    {it.check !== undefined && (
+            const ordered = list.ordered;
+            const items = list.items.map((it, idx) => {
+                // An ordered list keeps its native list-decimal marker, so it must NOT
+                // become a flex row and must not get a bullet injected - either would
+                // suppress the number. Only unordered rows use the flex + marker layout.
+                const marker =
+                    it.check !== undefined ? (
                         <input
                             type="checkbox"
                             checked={it.check}
                             readOnly
                             className="mt-1.5 shrink-0 accent-accent-cyan"
                         />
-                    )}
-                    {it.check === undefined && (
+                    ) : ordered ? null : (
                         <span className="mt-1.5 size-1.5 rounded-full bg-accent-cyan shrink-0" />
-                    )}
-                    <span>{renderInline(it.text, `${key}-${idx}`)}</span>
-                </li>
-            ));
+                    );
+                return (
+                    <li
+                        // biome-ignore lint/suspicious/noArrayIndexKey: parsed output is rebuilt from scratch on every render and never reordered
+                        key={`${key}-${idx}`}
+                        className={
+                            marker
+                                ? "leading-relaxed flex gap-2 items-start"
+                                : "leading-relaxed"
+                        }
+                    >
+                        {marker}
+                        {marker ? (
+                            <span>
+                                {renderInline(it.text, `${key}-${idx}`)}
+                            </span>
+                        ) : (
+                            renderInline(it.text, `${key}-${idx}`)
+                        )}
+                    </li>
+                );
+            });
             blocks.push(
-                list.ordered ? (
+                ordered ? (
                     <ol key={key} className="my-2 space-y-1 list-decimal pl-5">
                         {items}
                     </ol>

--- a/src/components/recordings/rich-content.tsx
+++ b/src/components/recordings/rich-content.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import type { JSX, ReactNode } from "react";
+import {
+    type JSX,
+    type ReactNode,
+    useCallback,
+    useMemo,
+    useState,
+} from "react";
+import { Input } from "@/components/ui/input";
+import type { SpeakerNameMap } from "@/types/speaker";
 
 function isSafeImageSrc(src: string): boolean {
     return src.startsWith("/api/plaud-assets/") || src.startsWith("https://");
@@ -331,6 +339,31 @@ const SPEAKER_COLORS = [
     "text-sky-400",
 ];
 
+const MAX_SPEAKER_NAME_LENGTH = 200;
+
+interface SpeakerTurn {
+    speaker: string | null;
+    text: string;
+}
+
+function parseSpeakerTurns(text: string): SpeakerTurn[] {
+    const lines = text
+        .replace(/\r\n/g, "\n")
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+
+    const turns: SpeakerTurn[] = [];
+    for (const line of lines) {
+        const m = line.match(SPEAKER_RE);
+        if (m) turns.push({ speaker: m[1], text: m[2] });
+        else if (turns.length && turns[turns.length - 1].speaker === null)
+            turns[turns.length - 1].text += ` ${line}`;
+        else turns.push({ speaker: null, text: line });
+    }
+    return turns;
+}
+
 /**
  * Render a diarized transcript as one block per speaker turn, colouring
  * each speaker label consistently in order of first appearance.
@@ -339,29 +372,50 @@ const SPEAKER_COLORS = [
  * one turn per line. A line with no recognised label is appended to the
  * preceding unlabelled turn. When no line carries a label at all (a plain
  * Whisper transcript, for example) the whole text is rendered as
- * pre-wrapped plain text, which is the previous behaviour.
+ * pre-wrapped plain text.
+ *
+ * `speakerNames` swaps the raw diarization label for a human name at
+ * render time. The transcript text is never rewritten, so the label stays
+ * the stable key, and colours are assigned from that raw label so a
+ * speaker's colour survives a rename.
+ *
+ * Supplying `onRenameSpeaker` turns each label into a click-to-edit chip:
+ * Enter saves, Escape cancels, and saving an empty value clears the name.
+ * Without it the labels render read-only.
  */
 export function SpeakerTranscript({
     text,
     className,
+    speakerNames,
+    onRenameSpeaker,
 }: {
     text: string;
     className?: string;
+    speakerNames?: SpeakerNameMap;
+    onRenameSpeaker?: (speakerLabel: string, displayName: string) => void;
 }): JSX.Element {
-    const lines = text
-        .replace(/\r\n/g, "\n")
-        .split("\n")
-        .map((l) => l.trim())
-        .filter(Boolean);
+    const [editingTurn, setEditingTurn] = useState<number | null>(null);
+    const [draft, setDraft] = useState("");
 
-    const turns: { speaker: string | null; text: string }[] = [];
-    for (const line of lines) {
-        const m = line.match(SPEAKER_RE);
-        if (m) turns.push({ speaker: m[1], text: m[2] });
-        else if (turns.length && turns[turns.length - 1].speaker === null)
-            turns[turns.length - 1].text += ` ${line}`;
-        else turns.push({ speaker: null, text: line });
-    }
+    const turns = useMemo(() => parseSpeakerTurns(text), [text]);
+
+    const colorByLabel = useMemo(() => {
+        const colors: Record<string, string> = {};
+        let assigned = 0;
+        for (const turn of turns) {
+            if (!turn.speaker || colors[turn.speaker]) continue;
+            colors[turn.speaker] =
+                SPEAKER_COLORS[assigned++ % SPEAKER_COLORS.length];
+        }
+        return colors;
+    }, [turns]);
+
+    // Stable identity so React only re-attaches (and re-focuses) the ref
+    // when the input actually mounts, not on every keystroke.
+    const focusOnMount = useCallback((el: HTMLInputElement | null) => {
+        el?.focus();
+        el?.select();
+    }, []);
 
     const hasSpeakers = turns.some((t) => t.speaker !== null);
     if (!hasSpeakers) {
@@ -374,31 +428,101 @@ export function SpeakerTranscript({
         );
     }
 
-    const order: string[] = [];
-    const colorFor = (speaker: string) => {
-        let idx = order.indexOf(speaker);
-        if (idx === -1) {
-            order.push(speaker);
-            idx = order.length - 1;
-        }
-        return SPEAKER_COLORS[idx % SPEAKER_COLORS.length];
+    const editable = typeof onRenameSpeaker === "function";
+
+    const startEditing = (index: number, label: string) => {
+        setDraft(speakerNames?.[label]?.displayName ?? "");
+        setEditingTurn(index);
+    };
+
+    const commit = (label: string) => {
+        setEditingTurn(null);
+        onRenameSpeaker?.(label, draft);
     };
 
     return (
         <div className={`space-y-3 ${className ?? ""}`}>
-            {turns.map((t, i) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: turns are reparsed from the transcript on every render and never reordered
-                <div key={`turn-${i}`} className="leading-relaxed">
-                    {t.speaker && (
-                        <span
-                            className={`font-semibold ${colorFor(t.speaker)} mr-2`}
-                        >
-                            {t.speaker}:
-                        </span>
-                    )}
-                    <span>{t.text}</span>
-                </div>
-            ))}
+            {turns.map((t, i) => {
+                const label = t.speaker;
+                if (!label) {
+                    return (
+                        // biome-ignore lint/suspicious/noArrayIndexKey: turns are reparsed from the transcript on every render and never reordered
+                        <div key={`turn-${i}`} className="leading-relaxed">
+                            <span>{t.text}</span>
+                        </div>
+                    );
+                }
+
+                const stored = speakerNames?.[label];
+                const isAuto = stored?.source === "auto";
+                const shown = stored?.displayName ?? label;
+                const color = colorByLabel[label] ?? SPEAKER_COLORS[0];
+                const confidence =
+                    isAuto && typeof stored?.confidence === "number"
+                        ? ` ${Math.round(stored.confidence * 100)}% match.`
+                        : "";
+
+                return (
+                    // biome-ignore lint/suspicious/noArrayIndexKey: turns are reparsed from the transcript on every render and never reordered
+                    <div key={`turn-${i}`} className="leading-relaxed">
+                        {editingTurn === i ? (
+                            <Input
+                                ref={focusOnMount}
+                                value={draft}
+                                placeholder={label}
+                                maxLength={MAX_SPEAKER_NAME_LENGTH}
+                                aria-label={`Name for ${label}`}
+                                className="mr-2 inline-flex h-6 w-44 px-2 py-0 text-sm md:text-sm"
+                                onChange={(e) => setDraft(e.target.value)}
+                                onBlur={() => setEditingTurn(null)}
+                                onKeyDown={(e) => {
+                                    if (e.key === "Enter") {
+                                        e.preventDefault();
+                                        commit(label);
+                                    } else if (e.key === "Escape") {
+                                        e.preventDefault();
+                                        setEditingTurn(null);
+                                    }
+                                }}
+                            />
+                        ) : (
+                            <span
+                                className={`mr-2 inline-flex items-baseline gap-1 ${color}`}
+                            >
+                                {editable ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => startEditing(i, label)}
+                                        title={`${label}.${confidence} Click to rename.`}
+                                        className={`cursor-pointer rounded font-semibold hover:underline focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none ${color} ${
+                                            isAuto ? "opacity-80" : ""
+                                        }`}
+                                    >
+                                        {shown}:
+                                    </button>
+                                ) : (
+                                    <span
+                                        className={`font-semibold ${color} ${
+                                            isAuto ? "opacity-80" : ""
+                                        }`}
+                                    >
+                                        {shown}:
+                                    </span>
+                                )}
+                                {isAuto && (
+                                    <span
+                                        title={`Matched by voice.${confidence}`}
+                                        className="text-[10px] tracking-wide text-muted-foreground uppercase"
+                                    >
+                                        auto
+                                    </span>
+                                )}
+                            </span>
+                        )}
+                        <span>{t.text}</span>
+                    </div>
+                );
+            })}
         </div>
     );
 }

--- a/src/db/migrations/0038_outstanding_archangel.sql
+++ b/src/db/migrations/0038_outstanding_archangel.sql
@@ -1,0 +1,32 @@
+CREATE TABLE "speaker_names" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"recording_id" text NOT NULL,
+	"speaker_label" varchar(50) NOT NULL,
+	"display_name" text NOT NULL,
+	"voice_profile_id" text,
+	"source" varchar(20) DEFAULT 'manual' NOT NULL,
+	"confidence" real,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "speaker_names_recording_id_speaker_label_unique" UNIQUE("recording_id","speaker_label")
+);
+--> statement-breakpoint
+CREATE TABLE "voice_profiles" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"display_name" text NOT NULL,
+	"embedding" jsonb NOT NULL,
+	"sample_count" integer DEFAULT 1 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "voice_profiles_user_id_display_name_unique" UNIQUE("user_id","display_name")
+);
+--> statement-breakpoint
+ALTER TABLE "speaker_names" ADD CONSTRAINT "speaker_names_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "speaker_names" ADD CONSTRAINT "speaker_names_recording_id_recordings_id_fk" FOREIGN KEY ("recording_id") REFERENCES "public"."recordings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "speaker_names" ADD CONSTRAINT "speaker_names_voice_profile_id_voice_profiles_id_fk" FOREIGN KEY ("voice_profile_id") REFERENCES "public"."voice_profiles"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "voice_profiles" ADD CONSTRAINT "voice_profiles_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "speaker_names_recording_id_idx" ON "speaker_names" USING btree ("recording_id");--> statement-breakpoint
+CREATE INDEX "speaker_names_user_id_idx" ON "speaker_names" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "voice_profiles_user_id_idx" ON "voice_profiles" USING btree ("user_id");

--- a/src/db/migrations/meta/0038_snapshot.json
+++ b/src/db/migrations/meta/0038_snapshot.json
@@ -1,0 +1,3796 @@
+{
+  "id": "545db587-8fb2-4562-9556-79ed06ae7689",
+  "prevId": "eff627c9-f994-4dcd-8768-6902228b4d3c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_action_log": {
+      "name": "admin_action_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_user_email": {
+          "name": "admin_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource_id": {
+          "name": "target_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_action_log_created_idx": {
+          "name": "admin_action_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_action_log_target_user_idx": {
+          "name": "admin_action_log_target_user_idx",
+          "columns": [
+            {
+              "expression": "target_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_action_log_admin_user_id_users_id_fk": {
+          "name": "admin_action_log_admin_user_id_users_id_fk",
+          "tableFrom": "admin_action_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_user_email": {
+          "name": "admin_user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_audit_log_admin_created_idx": {
+          "name": "admin_audit_log_admin_created_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_audit_log_created_idx": {
+          "name": "admin_audit_log_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_audit_log_admin_user_id_users_id_fk": {
+          "name": "admin_audit_log_admin_user_id_users_id_fk",
+          "tableFrom": "admin_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_enhancements": {
+      "name": "ai_enhancements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_points": {
+          "name": "key_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'riffado'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_enhancements_recording_id_recordings_id_fk": {
+          "name": "ai_enhancements_recording_id_recordings_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_enhancements_user_id_users_id_fk": {
+          "name": "ai_enhancements_user_id_users_id_fk",
+          "tableFrom": "ai_enhancements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ai_enhancements_recording_id_user_id_unique": {
+          "name": "ai_enhancements_recording_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recording_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_credentials": {
+      "name": "api_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default_transcription": {
+          "name": "is_default_transcription",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_enhancement": {
+          "name": "is_default_enhancement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_credentials_user_id_users_id_fk": {
+          "name": "api_credentials_user_id_users_id_fk",
+          "tableFrom": "api_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "api_key_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"read\"]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_rate_limit_buckets": {
+      "name": "api_rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_rate_limit_buckets_reset_at_idx": {
+          "name": "api_rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_customers": {
+      "name": "billing_customers",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "billing_customers_user_id_users_id_fk": {
+          "name": "billing_customers_user_id_users_id_fk",
+          "tableFrom": "billing_customers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_customers_stripe_customer_id_unique": {
+          "name": "billing_customers_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_campaigns": {
+      "name": "email_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_campaigns_slug_unique": {
+          "name": "email_campaigns_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_deliveries": {
+      "name": "email_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_id": {
+          "name": "subscriber_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_deliveries_campaign_status_idx": {
+          "name": "email_deliveries_campaign_status_idx",
+          "columns": [
+            {
+              "expression": "campaign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_deliveries_user_id_idx": {
+          "name": "email_deliveries_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_deliveries_campaign_id_email_campaigns_id_fk": {
+          "name": "email_deliveries_campaign_id_email_campaigns_id_fk",
+          "tableFrom": "email_deliveries",
+          "tableTo": "email_campaigns",
+          "columnsFrom": [
+            "campaign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_deliveries_user_id_users_id_fk": {
+          "name": "email_deliveries_user_id_users_id_fk",
+          "tableFrom": "email_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_deliveries_subscriber_id_newsletter_subscriptions_id_fk": {
+          "name": "email_deliveries_subscriber_id_newsletter_subscriptions_id_fk",
+          "tableFrom": "email_deliveries",
+          "tableTo": "newsletter_subscriptions",
+          "columnsFrom": [
+            "subscriber_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_deliveries_campaign_email_unique": {
+          "name": "email_deliveries_campaign_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "campaign_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_log": {
+      "name": "email_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_log_user_id_users_id_fk": {
+          "name": "email_log_user_id_users_id_fk",
+          "tableFrom": "email_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_log_user_kind_unique": {
+          "name": "email_log_user_kind_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "kind"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_created_at_idx": {
+          "name": "email_suppressions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_validations": {
+      "name": "email_validations",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reachable": {
+          "name": "reachable",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disposable": {
+          "name": "is_disposable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_role_account": {
+          "name": "is_role_account",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_full_inbox": {
+          "name": "has_full_inbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_catch_all": {
+          "name": "is_catch_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mx_accepts": {
+          "name": "mx_accepts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reacher-stacked'"
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_validations_checked_at_idx": {
+          "name": "email_validations_checked_at_idx",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "export_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recording_count": {
+          "name": "recording_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stale_storage_keys": {
+          "name": "stale_storage_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "export_jobs_user_id_idx": {
+          "name": "export_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_jobs_status_created_at_idx": {
+          "name": "export_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_jobs_expires_at_idx": {
+          "name": "export_jobs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "export_jobs_user_active_unique": {
+          "name": "export_jobs_user_active_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"export_jobs\".\"status\" in ('pending', 'processing')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "export_jobs_user_id_users_id_fk": {
+          "name": "export_jobs_user_id_users_id_fk",
+          "tableFrom": "export_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.founding_member_reservations": {
+      "name": "founding_member_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "founding_member_reservation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "reserved_at": {
+          "name": "reserved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "founding_member_reservations_status_expires_at_idx": {
+          "name": "founding_member_reservations_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founding_member_reservations_user_status_idx": {
+          "name": "founding_member_reservations_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founding_member_reservations_user_reserved_unique": {
+          "name": "founding_member_reservations_user_reserved_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"founding_member_reservations\".\"status\" = 'reserved'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "founding_member_reservations_user_id_users_id_fk": {
+          "name": "founding_member_reservations_user_id_users_id_fk",
+          "tableFrom": "founding_member_reservations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "founding_member_reservations_stripe_checkout_session_id_unique": {
+          "name": "founding_member_reservations_stripe_checkout_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_checkout_session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.install_script_hits": {
+      "name": "install_script_hits",
+      "schema": "",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "install_script_hits_day_version_pk": {
+          "name": "install_script_hits_day_version_pk",
+          "columns": [
+            "day",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscriptions": {
+      "name": "newsletter_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscriptions_confirmed_at_idx": {
+          "name": "newsletter_subscriptions_confirmed_at_idx",
+          "columns": [
+            {
+              "expression": "confirmed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscriptions_email_unique": {
+          "name": "newsletter_subscriptions_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_connections": {
+      "name": "plaud_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_base": {
+          "name": "api_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://api.plaud.ai'"
+        },
+        "plaud_email": {
+          "name": "plaud_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalidated_at": {
+          "name": "invalidated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync": {
+          "name": "last_sync",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plaud_connections_user_id_users_id_fk": {
+          "name": "plaud_connections_user_id_users_id_fk",
+          "tableFrom": "plaud_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plaud_devices": {
+      "name": "plaud_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "plaud_devices_user_id_idx": {
+          "name": "plaud_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plaud_devices_user_id_users_id_fk": {
+          "name": "plaud_devices_user_id_users_id_fk",
+          "tableFrom": "plaud_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plaud_devices_user_id_serial_number_unique": {
+          "name": "plaud_devices_user_id_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recordings": {
+      "name": "recordings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_sn": {
+          "name": "device_sn",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaud_file_id": {
+          "name": "plaud_file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_md5": {
+          "name": "file_md5",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaud_version": {
+          "name": "plaud_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zonemins": {
+          "name": "zonemins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_trash": {
+          "name": "is_trash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "waveform_peaks": {
+          "name": "waveform_peaks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recordings_user_id_idx": {
+          "name": "recordings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_plaud_file_id_idx": {
+          "name": "recordings_plaud_file_id_idx",
+          "columns": [
+            {
+              "expression": "plaud_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_user_id_start_time_idx": {
+          "name": "recordings_user_id_start_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recordings_user_id_users_id_fk": {
+          "name": "recordings_user_id_users_id_fk",
+          "tableFrom": "recordings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recordings_user_id_plaud_file_id_unique": {
+          "name": "recordings_user_id_plaud_file_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "plaud_file_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.speaker_names": {
+      "name": "speaker_names",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker_label": {
+          "name": "speaker_label",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voice_profile_id": {
+          "name": "voice_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "speaker_names_recording_id_idx": {
+          "name": "speaker_names_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "speaker_names_user_id_idx": {
+          "name": "speaker_names_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "speaker_names_user_id_users_id_fk": {
+          "name": "speaker_names_user_id_users_id_fk",
+          "tableFrom": "speaker_names",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "speaker_names_recording_id_recordings_id_fk": {
+          "name": "speaker_names_recording_id_recordings_id_fk",
+          "tableFrom": "speaker_names",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "speaker_names_voice_profile_id_voice_profiles_id_fk": {
+          "name": "speaker_names_voice_profile_id_voice_profiles_id_fk",
+          "tableFrom": "speaker_names",
+          "tableTo": "voice_profiles",
+          "columnsFrom": [
+            "voice_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "speaker_names_recording_id_speaker_label_unique": {
+          "name": "speaker_names_recording_id_speaker_label_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recording_id",
+            "speaker_label"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_webhook_event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_webhook_events_due_idx": {
+          "name": "stripe_webhook_events_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_webhook_events_created_at_idx": {
+          "name": "stripe_webhook_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_value": {
+          "name": "amount_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_currency": {
+          "name": "amount_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_country": {
+          "name": "billing_country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_payment_at": {
+          "name": "next_payment_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawal_waiver_accepted_at": {
+          "name": "withdrawal_waiver_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_active_unique": {
+          "name": "subscriptions_user_id_active_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscriptions\".\"status\" IN ('active', 'trialing', 'past_due')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_user_status_idx": {
+          "name": "subscriptions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcriptions": {
+      "name": "transcriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detected_language": {
+          "name": "detected_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_type": {
+          "name": "transcription_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'server'"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'riffado'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transcriptions_recording_id_idx": {
+          "name": "transcriptions_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transcriptions_user_id_idx": {
+          "name": "transcriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transcriptions_recording_id_recordings_id_fk": {
+          "name": "transcriptions_recording_id_recordings_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transcriptions_user_id_users_id_fk": {
+          "name": "transcriptions_user_id_users_id_fk",
+          "tableFrom": "transcriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transcriptions_recording_user_source_unique": {
+          "name": "transcriptions_recording_user_source_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recording_id",
+            "user_id",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_interval": {
+          "name": "sync_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300000
+        },
+        "auto_transcribe": {
+          "name": "auto_transcribe",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_summarize": {
+          "name": "auto_summarize",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_summarize_preset": {
+          "name": "auto_summarize_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_mount": {
+          "name": "sync_on_mount",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_on_visibility_change": {
+          "name": "sync_on_visibility_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_notifications": {
+          "name": "sync_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_playback_speed": {
+          "name": "default_playback_speed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_volume": {
+          "name": "default_volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 75
+        },
+        "auto_play_next": {
+          "name": "auto_play_next",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "player_scrubber": {
+          "name": "player_scrubber",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waveform'"
+        },
+        "default_transcription_language": {
+          "name": "default_transcription_language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcription_quality": {
+          "name": "transcription_quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'balanced'"
+        },
+        "import_plaud_content": {
+          "name": "import_plaud_content",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transcript_mode": {
+          "name": "transcript_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'plaud_only'"
+        },
+        "preferred_transcript_source": {
+          "name": "preferred_transcript_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'plaud'"
+        },
+        "default_transcription_provider_id": {
+          "name": "default_transcription_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_time_format": {
+          "name": "date_time_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'relative'"
+        },
+        "recording_list_sort_order": {
+          "name": "recording_list_sort_order",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'newest'"
+        },
+        "items_per_page": {
+          "name": "items_per_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "list_density": {
+          "name": "list_density",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'comfortable'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "auto_delete_recordings": {
+          "name": "auto_delete_recordings",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser_notifications": {
+          "name": "browser_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "bark_notifications": {
+          "name": "bark_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_sound": {
+          "name": "notification_sound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bark_push_url": {
+          "name": "bark_push_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_export_format": {
+          "name": "default_export_format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'json'"
+        },
+        "auto_export": {
+          "name": "auto_export",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backup_frequency": {
+          "name": "backup_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_providers": {
+          "name": "default_providers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_generate_title": {
+          "name": "auto_generate_title",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sync_title_to_plaud": {
+          "name": "sync_title_to_plaud",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title_generation_prompt": {
+          "name": "title_generation_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_prompt": {
+          "name": "summary_prompt",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_output_language": {
+          "name": "ai_output_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marketing_email_consent": {
+          "name": "marketing_email_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_transition_until": {
+          "name": "plan_transition_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_mynah_seconds_remaining": {
+          "name": "monthly_mynah_seconds_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthly_mynah_grant_reset_at": {
+          "name": "monthly_mynah_grant_reset_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founding_member": {
+          "name": "founding_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "founding_member_claimed_at": {
+          "name": "founding_member_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ever_paid_at": {
+          "name": "ever_paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_deletion_scheduled_at": {
+          "name": "account_deletion_scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_profiles": {
+      "name": "voice_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "voice_profiles_user_id_idx": {
+          "name": "voice_profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "voice_profiles_user_id_users_id_fk": {
+          "name": "voice_profiles_user_id_users_id_fk",
+          "tableFrom": "voice_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "voice_profiles_user_id_display_name_unique": {
+          "name": "voice_profiles_user_id_display_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "display_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_response_status": {
+          "name": "last_response_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_pending_idx": {
+          "name": "webhook_deliveries_pending_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_endpoint_id_idx": {
+          "name": "webhook_deliveries_endpoint_id_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recording_id_idx": {
+          "name": "webhook_deliveries_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_user_id_users_id_fk": {
+          "name": "webhook_deliveries_user_id_users_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_deliveries_recording_id_recordings_id_fk": {
+          "name": "webhook_deliveries_recording_id_recordings_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_delivery_at": {
+          "name": "last_delivery_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_delivery_status": {
+          "name": "last_delivery_status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_endpoints_user_id_idx": {
+          "name": "webhook_endpoints_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_endpoints_user_id_users_id_fk": {
+          "name": "webhook_endpoints_user_id_users_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.api_key_source": {
+      "name": "api_key_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "device-flow"
+      ]
+    },
+    "public.export_job_status": {
+      "name": "export_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.founding_member_reservation_status": {
+      "name": "founding_member_reservation_status",
+      "schema": "public",
+      "values": [
+        "reserved",
+        "consumed",
+        "released",
+        "expired"
+      ]
+    },
+    "public.stripe_webhook_event_status": {
+      "name": "stripe_webhook_event_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "self_host",
+        "hosted_free",
+        "hosted_pro"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1785230494218,
       "tag": "0037_thankful_silver_samurai",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1788268316571,
+      "tag": "0038_outstanding_archangel",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -395,6 +395,90 @@ export const aiEnhancements = pgTable(
     }),
 );
 
+/**
+ * A known person's voice, stored as the centroid of every speaker
+ * embedding observed for them. One row per person per user, which is what
+ * lets a name learned on one recording auto-tag the same voice on the
+ * next one.
+ *
+ * `displayName` is the identity key (unique per user) because that is the
+ * only handle the caller supplying embeddings has for a person.
+ */
+export const voiceProfiles = pgTable(
+    "voice_profiles",
+    {
+        id: text("id")
+            .primaryKey()
+            .$defaultFn(() => nanoid()),
+        userId: text("user_id")
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        displayName: text("display_name").notNull(),
+        // Centroid of the samples that formed this profile. jsonb rather
+        // than a pgvector column so the schema stays portable to a stock
+        // Postgres image: the candidate set is one user's own profiles,
+        // small enough to cosine-match in application code.
+        embedding: jsonb("embedding").$type<number[]>().notNull(),
+        sampleCount: integer("sample_count").notNull().default(1),
+        createdAt: timestamp("created_at").notNull().defaultNow(),
+        updatedAt: timestamp("updated_at").notNull().defaultNow(),
+    },
+    (table) => ({
+        userIdIdx: index("voice_profiles_user_id_idx").on(table.userId),
+        userDisplayNameUnique: unique(
+            "voice_profiles_user_id_display_name_unique",
+        ).on(table.userId, table.displayName),
+    }),
+);
+
+/**
+ * Human name for one diarized speaker label inside one recording
+ * ("SPEAKER_00" -> "Alice"). The transcript text is never rewritten; the
+ * label stays the stable key and this row is the display layer.
+ *
+ * `source` records who named the speaker: 'manual' (the user, in the
+ * transcript UI) or 'auto' (a voice-embedding match, with `confidence`
+ * holding the cosine similarity). A manual row is authoritative and is
+ * never overwritten by an auto match.
+ */
+export const speakerNames = pgTable(
+    "speaker_names",
+    {
+        id: text("id")
+            .primaryKey()
+            .$defaultFn(() => nanoid()),
+        userId: text("user_id")
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        recordingId: text("recording_id")
+            .notNull()
+            .references(() => recordings.id, { onDelete: "cascade" }),
+        speakerLabel: varchar("speaker_label", { length: 50 }).notNull(),
+        displayName: text("display_name").notNull(),
+        // Set null (not cascade) so deleting a voice profile downgrades the
+        // name to a plain label-to-name mapping instead of erasing it.
+        voiceProfileId: text("voice_profile_id").references(
+            () => voiceProfiles.id,
+            { onDelete: "set null" },
+        ),
+        source: varchar("source", { length: 20 }).notNull().default("manual"),
+        // Cosine similarity of the match when source = 'auto'; null for
+        // manual names.
+        confidence: real("confidence"),
+        createdAt: timestamp("created_at").notNull().defaultNow(),
+        updatedAt: timestamp("updated_at").notNull().defaultNow(),
+    },
+    (table) => ({
+        recordingIdIdx: index("speaker_names_recording_id_idx").on(
+            table.recordingId,
+        ),
+        userIdIdx: index("speaker_names_user_id_idx").on(table.userId),
+        recordingSpeakerLabelUnique: unique(
+            "speaker_names_recording_id_speaker_label_unique",
+        ).on(table.recordingId, table.speakerLabel),
+    }),
+);
+
 // API Credentials (encrypted)
 export const apiCredentials = pgTable("api_credentials", {
     id: text("id")

--- a/src/hooks/use-speaker-names.ts
+++ b/src/hooks/use-speaker-names.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import {
+    indexSpeakerNames,
+    type SpeakerName,
+    type SpeakerNameMap,
+} from "@/types/speaker";
+
+/**
+ * Speaker names for one recording plus the writer the transcript UI uses
+ * to rename them inline.
+ *
+ * Names are fetched once per recording and written optimistically: the
+ * chip updates immediately and only rolls back if the request fails.
+ * Passing an empty `displayName` clears the name, dropping the speaker
+ * back to its raw diarization label.
+ *
+ * A rename always lands as `source: 'manual'`, because renaming an
+ * auto-matched speaker usually means the match itself was wrong.
+ */
+export function useSpeakerNames(recordingId: string | null | undefined) {
+    const [speakerNames, setSpeakerNames] = useState<SpeakerNameMap>({});
+
+    useEffect(() => {
+        setSpeakerNames({});
+        if (!recordingId) return;
+
+        const controller = new AbortController();
+        fetch(`/api/recordings/${recordingId}/speakers`, {
+            signal: controller.signal,
+        })
+            .then((response) => (response.ok ? response.json() : null))
+            .then((data: { speakers?: SpeakerName[] } | null) => {
+                if (data?.speakers) {
+                    setSpeakerNames(indexSpeakerNames(data.speakers));
+                }
+            })
+            .catch(() => {});
+
+        return () => controller.abort();
+    }, [recordingId]);
+
+    const renameSpeaker = useCallback(
+        async (speakerLabel: string, displayName: string) => {
+            if (!recordingId) return;
+
+            const name = displayName.trim();
+            const previous = speakerNames;
+            const existing = previous[speakerLabel];
+
+            if (!name) {
+                if (!existing) return;
+                setSpeakerNames(
+                    Object.fromEntries(
+                        Object.entries(previous).filter(
+                            ([label]) => label !== speakerLabel,
+                        ),
+                    ),
+                );
+                try {
+                    const response = await fetch(
+                        `/api/recordings/${recordingId}/speakers?label=${encodeURIComponent(speakerLabel)}`,
+                        { method: "DELETE" },
+                    );
+                    if (!response.ok) throw new Error("request failed");
+                } catch {
+                    setSpeakerNames(previous);
+                    toast.error("Failed to clear speaker name");
+                }
+                return;
+            }
+
+            if (
+                existing?.displayName === name &&
+                existing.source === "manual"
+            ) {
+                return;
+            }
+
+            setSpeakerNames({
+                ...previous,
+                [speakerLabel]: {
+                    speakerLabel,
+                    displayName: name,
+                    source: "manual",
+                    confidence: null,
+                    voiceProfileId: null,
+                    updatedAt: new Date().toISOString(),
+                },
+            });
+
+            try {
+                const response = await fetch(
+                    `/api/recordings/${recordingId}/speakers`,
+                    {
+                        method: "PUT",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({
+                            speakerLabel,
+                            displayName: name,
+                        }),
+                    },
+                );
+                if (!response.ok) throw new Error("request failed");
+                const data = (await response.json()) as {
+                    speaker?: SpeakerName;
+                };
+                const saved = data.speaker;
+                if (saved) {
+                    setSpeakerNames((current) => ({
+                        ...current,
+                        [speakerLabel]: saved,
+                    }));
+                }
+            } catch {
+                setSpeakerNames(previous);
+                toast.error("Failed to rename speaker");
+            }
+        },
+        [recordingId, speakerNames],
+    );
+
+    return { speakerNames, renameSpeaker };
+}

--- a/src/hooks/use-speaker-names.ts
+++ b/src/hooks/use-speaker-names.ts
@@ -1,7 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import {
+    nextSpeakerEditGeneration,
+    rollbackSpeakerName,
+    shouldApplySpeakerEdit,
+} from "@/lib/speakers/rename-state";
 import {
     indexSpeakerNames,
     type SpeakerName,
@@ -22,9 +27,15 @@ import {
  */
 export function useSpeakerNames(recordingId: string | null | undefined) {
     const [speakerNames, setSpeakerNames] = useState<SpeakerNameMap>({});
+    const speakerNamesRef = useRef<SpeakerNameMap>({});
+    const generationsRef = useRef(new Map<string, number>());
+
+    speakerNamesRef.current = speakerNames;
 
     useEffect(() => {
         setSpeakerNames({});
+        speakerNamesRef.current = {};
+        generationsRef.current = new Map();
         if (!recordingId) return;
 
         const controller = new AbortController();
@@ -34,7 +45,9 @@ export function useSpeakerNames(recordingId: string | null | undefined) {
             .then((response) => (response.ok ? response.json() : null))
             .then((data: { speakers?: SpeakerName[] } | null) => {
                 if (data?.speakers) {
-                    setSpeakerNames(indexSpeakerNames(data.speakers));
+                    const next = indexSpeakerNames(data.speakers);
+                    speakerNamesRef.current = next;
+                    setSpeakerNames(next);
                 }
             })
             .catch(() => {});
@@ -47,17 +60,42 @@ export function useSpeakerNames(recordingId: string | null | undefined) {
             if (!recordingId) return;
 
             const name = displayName.trim();
-            const previous = speakerNames;
-            const existing = previous[speakerLabel];
+            const previousForLabel = speakerNamesRef.current[speakerLabel];
+
+            if (!name && !previousForLabel) return;
+            if (
+                name &&
+                previousForLabel?.displayName === name &&
+                previousForLabel.source === "manual"
+            ) {
+                return;
+            }
+
+            const opGeneration = nextSpeakerEditGeneration(
+                generationsRef.current,
+                speakerLabel,
+            );
+
+            const applyIfCurrent = (
+                updater: (current: SpeakerNameMap) => SpeakerNameMap,
+            ) => {
+                setSpeakerNames((current) => {
+                    if (
+                        !shouldApplySpeakerEdit(
+                            generationsRef.current,
+                            speakerLabel,
+                            opGeneration,
+                        )
+                    ) {
+                        return current;
+                    }
+                    return updater(current);
+                });
+            };
 
             if (!name) {
-                if (!existing) return;
-                setSpeakerNames(
-                    Object.fromEntries(
-                        Object.entries(previous).filter(
-                            ([label]) => label !== speakerLabel,
-                        ),
-                    ),
+                applyIfCurrent((current) =>
+                    rollbackSpeakerName(current, speakerLabel, undefined),
                 );
                 try {
                     const response = await fetch(
@@ -66,21 +104,20 @@ export function useSpeakerNames(recordingId: string | null | undefined) {
                     );
                     if (!response.ok) throw new Error("request failed");
                 } catch {
-                    setSpeakerNames(previous);
+                    applyIfCurrent((current) =>
+                        rollbackSpeakerName(
+                            current,
+                            speakerLabel,
+                            previousForLabel,
+                        ),
+                    );
                     toast.error("Failed to clear speaker name");
                 }
                 return;
             }
 
-            if (
-                existing?.displayName === name &&
-                existing.source === "manual"
-            ) {
-                return;
-            }
-
-            setSpeakerNames({
-                ...previous,
+            applyIfCurrent((current) => ({
+                ...current,
                 [speakerLabel]: {
                     speakerLabel,
                     displayName: name,
@@ -89,7 +126,7 @@ export function useSpeakerNames(recordingId: string | null | undefined) {
                     voiceProfileId: null,
                     updatedAt: new Date().toISOString(),
                 },
-            });
+            }));
 
             try {
                 const response = await fetch(
@@ -109,17 +146,23 @@ export function useSpeakerNames(recordingId: string | null | undefined) {
                 };
                 const saved = data.speaker;
                 if (saved) {
-                    setSpeakerNames((current) => ({
+                    applyIfCurrent((current) => ({
                         ...current,
                         [speakerLabel]: saved,
                     }));
                 }
             } catch {
-                setSpeakerNames(previous);
+                applyIfCurrent((current) =>
+                    rollbackSpeakerName(
+                        current,
+                        speakerLabel,
+                        previousForLabel,
+                    ),
+                );
                 toast.error("Failed to rename speaker");
             }
         },
-        [recordingId, speakerNames],
+        [recordingId],
     );
 
     return { speakerNames, renameSpeaker };

--- a/src/lib/speakers/embeddings.ts
+++ b/src/lib/speakers/embeddings.ts
@@ -1,0 +1,122 @@
+/**
+ * Speaker-embedding maths for voice-based speaker identification.
+ *
+ * Embeddings are produced outside Riffado (one fixed-width float vector
+ * per diarized speaker per recording) and POSTed in. Everything here is
+ * pure and transport-agnostic: validation helpers throw plain `Error`s
+ * and the route handlers map them onto HTTP status codes.
+ */
+
+/** Fixed embedding width. Vectors of any other length are rejected. */
+export const EMBEDDING_DIMENSIONS = 256;
+
+/** Minimum cosine similarity for an auto-match to be written. */
+export const SPEAKER_MATCH_THRESHOLD = 0.75;
+
+/** Decimal places kept when persisting a vector. */
+const STORED_DECIMALS = 6;
+
+function magnitude(vector: number[]): number {
+    let sum = 0;
+    for (const value of vector) sum += value * value;
+    return Math.sqrt(sum);
+}
+
+/** True when `value` is a usable embedding, without throwing. */
+export function isEmbedding(value: unknown): value is number[] {
+    if (!Array.isArray(value) || value.length !== EMBEDDING_DIMENSIONS) {
+        return false;
+    }
+    for (const entry of value) {
+        if (typeof entry !== "number" || !Number.isFinite(entry)) return false;
+    }
+    return magnitude(value as number[]) > 0;
+}
+
+/**
+ * Validate an untrusted embedding from a request body.
+ *
+ * @throws Error with a client-safe message when the value is not a
+ * finite, non-zero vector of exactly `EMBEDDING_DIMENSIONS` numbers.
+ */
+export function parseEmbedding(value: unknown, field = "embedding"): number[] {
+    if (!Array.isArray(value)) {
+        throw new Error(
+            `${field} must be an array of ${EMBEDDING_DIMENSIONS} numbers`,
+        );
+    }
+    if (value.length !== EMBEDDING_DIMENSIONS) {
+        throw new Error(
+            `${field} must contain exactly ${EMBEDDING_DIMENSIONS} numbers, received ${value.length}`,
+        );
+    }
+    const parsed: number[] = [];
+    for (const entry of value) {
+        if (typeof entry !== "number" || !Number.isFinite(entry)) {
+            throw new Error(`${field} must contain only finite numbers`);
+        }
+        parsed.push(entry);
+    }
+    if (magnitude(parsed) === 0) {
+        throw new Error(`${field} must not be a zero vector`);
+    }
+    return parsed;
+}
+
+/** Scale a vector to unit length. Zero vectors are returned unchanged. */
+export function normalizeEmbedding(vector: number[]): number[] {
+    const length = magnitude(vector);
+    if (length === 0) return [...vector];
+    return vector.map((value) => value / length);
+}
+
+/** Round to the persisted precision so stored vectors stay compact. */
+export function roundEmbedding(vector: number[]): number[] {
+    const factor = 10 ** STORED_DECIMALS;
+    return vector.map((value) => Math.round(value * factor) / factor);
+}
+
+/** Unit-length, rounded form of a vector, ready to store. */
+export function toStoredEmbedding(vector: number[]): number[] {
+    return roundEmbedding(normalizeEmbedding(vector));
+}
+
+/**
+ * Cosine similarity in [-1, 1]. Returns 0 for mismatched lengths or a
+ * zero-magnitude operand so a corrupt row can never win a match.
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+    if (a.length !== b.length || a.length === 0) return 0;
+    let dot = 0;
+    let normA = 0;
+    let normB = 0;
+    for (let i = 0; i < a.length; i++) {
+        dot += a[i] * b[i];
+        normA += a[i] * a[i];
+        normB += b[i] * b[i];
+    }
+    if (normA === 0 || normB === 0) return 0;
+    return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+/**
+ * Fold one new sample into a profile centroid.
+ *
+ * Both operands are unit-normalized first, so the centroid is a mean of
+ * directions rather than of magnitudes: an unusually loud sample cannot
+ * dominate the profile. `sampleCount` is the number of samples already
+ * folded in, so an established profile moves less per new sample.
+ */
+export function mergeCentroid(
+    centroid: number[],
+    sampleCount: number,
+    sample: number[],
+): number[] {
+    const weight = Math.max(1, Math.floor(sampleCount));
+    const current = normalizeEmbedding(centroid);
+    const incoming = normalizeEmbedding(sample);
+    const merged = current.map(
+        (value, i) => (value * weight + incoming[i]) / (weight + 1),
+    );
+    return toStoredEmbedding(merged);
+}

--- a/src/lib/speakers/match-write.ts
+++ b/src/lib/speakers/match-write.ts
@@ -1,0 +1,34 @@
+/** Postgres SQLSTATE for unique_violation. */
+const PG_UNIQUE_VIOLATION = "23505";
+
+export function isUniqueViolation(error: unknown): boolean {
+    const code = (error as { code?: unknown })?.code;
+    const causeCode = (error as { cause?: { code?: unknown } })?.cause?.code;
+    return code === PG_UNIQUE_VIOLATION || causeCode === PG_UNIQUE_VIOLATION;
+}
+
+export type LockedSpeakerName = {
+    id: string;
+    source: string;
+    displayName: string;
+};
+
+export type ConflictSpeakerOutcome =
+    | { action: "skip"; displayName: string }
+    | { action: "update"; id: string; displayName: string }
+    | { action: "none" };
+
+/**
+ * After an absent-row insert loses a unique race, classify the row that
+ * now exists. A manual name wins and must be reported as skipped; any
+ * other existing row can take a guarded auto update.
+ */
+export function classifyConflictSpeaker(
+    row: LockedSpeakerName | undefined,
+): ConflictSpeakerOutcome {
+    if (!row) return { action: "none" };
+    if (row.source === "manual") {
+        return { action: "skip", displayName: row.displayName };
+    }
+    return { action: "update", id: row.id, displayName: row.displayName };
+}

--- a/src/lib/speakers/rename-state.ts
+++ b/src/lib/speakers/rename-state.ts
@@ -1,0 +1,45 @@
+import type { SpeakerName, SpeakerNameMap } from "@/types/speaker";
+
+/** Bump and return the next edit generation for one speaker label. */
+export function nextSpeakerEditGeneration(
+    gens: Map<string, number>,
+    speakerLabel: string,
+): number {
+    const next = (gens.get(speakerLabel) ?? 0) + 1;
+    gens.set(speakerLabel, next);
+    return next;
+}
+
+export function speakerEditGeneration(
+    gens: ReadonlyMap<string, number>,
+    speakerLabel: string,
+): number {
+    return gens.get(speakerLabel) ?? 0;
+}
+
+/** True when `opGeneration` is still the latest edit for this label. */
+export function shouldApplySpeakerEdit(
+    gens: ReadonlyMap<string, number>,
+    speakerLabel: string,
+    opGeneration: number,
+): boolean {
+    return speakerEditGeneration(gens, speakerLabel) === opGeneration;
+}
+
+/**
+ * Restore one speaker label after a failed optimistic write, leaving
+ * every other label in `current` untouched.
+ */
+export function rollbackSpeakerName(
+    current: SpeakerNameMap,
+    speakerLabel: string,
+    previous: SpeakerName | undefined,
+): SpeakerNameMap {
+    if (previous === undefined) {
+        if (!(speakerLabel in current)) return current;
+        const next = { ...current };
+        delete next[speakerLabel];
+        return next;
+    }
+    return { ...current, [speakerLabel]: previous };
+}

--- a/src/lib/speakers/request.ts
+++ b/src/lib/speakers/request.ts
@@ -1,0 +1,91 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "@/db";
+import { recordings } from "@/db/schema";
+import { AppError, ErrorCode } from "@/lib/errors";
+
+/** Matches `speaker_names.speaker_label` (varchar(50)). */
+export const MAX_SPEAKER_LABEL_LENGTH = 50;
+export const MAX_DISPLAY_NAME_LENGTH = 200;
+/** Upper bound on labels accepted by a single match request. */
+export const MAX_SPEAKERS_PER_MATCH = 64;
+
+/** Wrap a validation `Error` as a 400 with a client-safe message. */
+export function speakerInputError(error: unknown): AppError {
+    return new AppError(
+        ErrorCode.INVALID_INPUT,
+        error instanceof Error ? error.message : "Invalid speaker payload",
+        400,
+    );
+}
+
+/**
+ * Diarization labels as the transcript renderer recognises them
+ * ("SPEAKER_00", "Speaker 1"). Anchored to start with an alphanumeric so
+ * a payload can never smuggle in a key like `__proto__`, which would
+ * poison the label-keyed maps the client builds.
+ */
+const SPEAKER_LABEL_RE = /^[A-Za-z0-9][A-Za-z0-9 ._'-]*$/;
+
+export function parseSpeakerLabel(value: unknown): string {
+    if (typeof value !== "string" || !value.trim()) {
+        throw new Error("speakerLabel is required");
+    }
+    const label = value.trim();
+    if (label.length > MAX_SPEAKER_LABEL_LENGTH) {
+        throw new Error(
+            `speakerLabel must be at most ${MAX_SPEAKER_LABEL_LENGTH} characters`,
+        );
+    }
+    if (!SPEAKER_LABEL_RE.test(label)) {
+        throw new Error(
+            "speakerLabel may only contain letters, digits, spaces, and . _ ' -",
+        );
+    }
+    return label;
+}
+
+export function parseDisplayName(value: unknown): string {
+    if (typeof value !== "string" || !value.trim()) {
+        throw new Error("displayName is required");
+    }
+    const name = value.trim();
+    if (name.length > MAX_DISPLAY_NAME_LENGTH) {
+        throw new Error(
+            `displayName must be at most ${MAX_DISPLAY_NAME_LENGTH} characters`,
+        );
+    }
+    return name;
+}
+
+/**
+ * Confirm the recording exists, belongs to `userId`, and is not
+ * tombstoned. Every speaker route calls this before touching
+ * `speaker_names` so a recording id from the URL can never reach another
+ * user's rows.
+ *
+ * @throws AppError 404 when the recording is not the caller's.
+ */
+export async function assertRecordingOwned(
+    recordingId: string,
+    userId: string,
+): Promise<void> {
+    const [recording] = await db
+        .select({ id: recordings.id })
+        .from(recordings)
+        .where(
+            and(
+                eq(recordings.id, recordingId),
+                eq(recordings.userId, userId),
+                isNull(recordings.deletedAt),
+            ),
+        )
+        .limit(1);
+
+    if (!recording) {
+        throw new AppError(
+            ErrorCode.RECORDING_NOT_FOUND,
+            "Recording not found",
+            404,
+        );
+    }
+}

--- a/src/tests/regressions/265-rich-content.test.ts
+++ b/src/tests/regressions/265-rich-content.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Regression for #265: Plaud markdown summaries and SPEAKER-labeled
+ * transcript turns render as React trees in the transcription panel.
+ * Non-diarized text stays pre-wrapped; href/src stay on the allowlist.
+ */
+
+// @vitest-environment jsdom
+
+import { render } from "@testing-library/react";
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+import {
+    RichMarkdown,
+    SpeakerTranscript,
+} from "@/components/recordings/rich-content";
+
+describe("RichMarkdown (#265)", () => {
+    it("renders Plaud headings, emphasis, lists, quotes, and rules", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: [
+                    "# Meeting Summary",
+                    "",
+                    "This is **bold** and *italic* and ~~old~~ and `code`.",
+                    "",
+                    "- first",
+                    "- second",
+                    "",
+                    "1. alpha",
+                    "2. beta",
+                    "",
+                    "- [x] done",
+                    "- [ ] later",
+                    "",
+                    "> quoted",
+                    "",
+                    "---",
+                ].join("\n"),
+            }),
+        );
+
+        expect(container.querySelector("h1")?.textContent).toBe(
+            "Meeting Summary",
+        );
+        expect(container.querySelector("strong")?.textContent).toBe("bold");
+        expect(container.querySelector("em")?.textContent).toBe("italic");
+        expect(container.querySelector("del")?.textContent).toBe("old");
+        expect(container.querySelector("code")?.textContent).toBe("code");
+        expect(
+            [...container.querySelectorAll("ul > li")].map((li) =>
+                li.textContent?.trim(),
+            ),
+        ).toEqual(["first", "second", "done", "later"]);
+        const olItems = [...container.querySelectorAll("ol > li")];
+        expect(olItems.map((li) => li.textContent?.trim())).toEqual([
+            "alpha",
+            "beta",
+        ]);
+        expect(container.querySelector("ol")?.className).toContain(
+            "list-decimal",
+        );
+        for (const li of olItems) {
+            expect(li.className).not.toContain("flex");
+        }
+        expect(
+            container.querySelectorAll('input[type="checkbox"]'),
+        ).toHaveLength(2);
+        expect(
+            (
+                container.querySelector(
+                    'input[type="checkbox"]',
+                ) as HTMLInputElement
+            ).checked,
+        ).toBe(true);
+        expect(container.querySelector("blockquote")?.textContent).toBe(
+            "quoted",
+        );
+        expect(container.querySelector("hr")).not.toBeNull();
+    });
+
+    it("allowlists https and same-origin hrefs and rejects the rest", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: [
+                    "[ok](https://example.com/a)",
+                    "[path](/settings)",
+                    "[proto](//evil.example/x)",
+                    "[slash](/\\\\evil.example/x)",
+                    "[js](javascript:alert(1))",
+                    "[data](data:text/html,hi)",
+                    "[http](http://example.com/a)",
+                ].join("\n"),
+            }),
+        );
+
+        const hrefs = [...container.querySelectorAll("a")].map((a) =>
+            a.getAttribute("href"),
+        );
+        expect(hrefs).toEqual(["https://example.com/a", "/settings"]);
+        expect(container.textContent).toContain("proto");
+        expect(container.textContent).toContain("js");
+        expect(container.textContent).toContain("data");
+        expect(container.textContent).toContain("http");
+    });
+
+    it("allowlists image srcs and leaves unsafe images as text", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: [
+                    "![safe](https://cdn.example/img.png)",
+                    "![asset](/api/plaud-assets/x.png)",
+                    "![js](javascript:alert(1))",
+                    "![data](data:image/png;base64,aaaa)",
+                    "![proto](//evil.example/x.png)",
+                ].join("\n"),
+            }),
+        );
+
+        const srcs = [...container.querySelectorAll("img")].map((img) =>
+            img.getAttribute("src"),
+        );
+        expect(srcs).toEqual([
+            "https://cdn.example/img.png",
+            "/api/plaud-assets/x.png",
+        ]);
+        const hrefs = [...container.querySelectorAll("a")].map((a) =>
+            a.getAttribute("href"),
+        );
+        expect(hrefs).toEqual([]);
+        expect(srcs.some((src) => src?.startsWith("javascript:"))).toBe(false);
+        expect(srcs.some((src) => src?.startsWith("data:"))).toBe(false);
+        expect(srcs.some((src) => src?.startsWith("//"))).toBe(false);
+    });
+
+    it("escapes HTML instead of injecting it", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: '<script>alert("xss")</script>',
+            }),
+        );
+        expect(container.querySelector("script")).toBeNull();
+        expect(container.innerHTML).not.toContain("dangerouslySetInnerHTML");
+        expect(container.textContent).toContain(
+            '<script>alert("xss")</script>',
+        );
+    });
+});
+
+describe("SpeakerTranscript (#265)", () => {
+    it("groups SPEAKER, Speaker n, and UNKNOWN turns", () => {
+        const { container } = render(
+            createElement(SpeakerTranscript, {
+                text: [
+                    "SPEAKER_00: hello",
+                    "Speaker 1: there",
+                    "UNKNOWN: who",
+                    "SPEAKER_00: again",
+                ].join("\n"),
+            }),
+        );
+
+        const turns = [...container.querySelectorAll(":scope > div > div")];
+        expect(turns).toHaveLength(4);
+        expect(turns[0].querySelector("span")?.textContent).toBe("SPEAKER_00:");
+        expect(turns[1].querySelector("span")?.textContent).toBe("Speaker 1:");
+        expect(turns[2].querySelector("span")?.textContent).toBe("UNKNOWN:");
+        expect(turns[0].textContent).toContain("hello");
+        expect(turns[3].textContent).toContain("again");
+        expect(turns[0].querySelector("span")?.className).toContain(
+            "text-accent-cyan",
+        );
+        expect(turns[3].querySelector("span")?.className).toContain(
+            "text-accent-cyan",
+        );
+        expect(turns[1].querySelector("span")?.className).toContain(
+            "text-emerald-400",
+        );
+    });
+
+    it("keeps non-diarized transcripts pre-wrapped", () => {
+        const text = "Question: what now?\nAction item: ship it\nJust prose.";
+        const { container } = render(
+            createElement(SpeakerTranscript, { text }),
+        );
+        const p = container.querySelector("p");
+        expect(p).not.toBeNull();
+        expect(p?.className).toContain("whitespace-pre-wrap");
+        expect(p?.textContent).toBe(text);
+        expect(container.querySelectorAll(":scope > div > div")).toHaveLength(
+            0,
+        );
+    });
+});

--- a/src/tests/regressions/268-speaker-match-conflict.test.ts
+++ b/src/tests/regressions/268-speaker-match-conflict.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Regression for #268 Greptile P1: an absent-row speaker match that
+ * races a concurrent manual rename must classify the new row as skipped
+ * (manual wins) instead of aborting the match batch.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+    classifyConflictSpeaker,
+    isUniqueViolation,
+} from "@/lib/speakers/match-write";
+
+describe("isUniqueViolation", () => {
+    it("recognizes Postgres 23505 on the error or its cause", () => {
+        expect(isUniqueViolation({ code: "23505" })).toBe(true);
+        expect(isUniqueViolation({ cause: { code: "23505" } })).toBe(true);
+        expect(isUniqueViolation(new Error("duplicate key"))).toBe(false);
+    });
+});
+
+describe("classifyConflictSpeaker", () => {
+    it("skips a concurrent manual row", () => {
+        expect(
+            classifyConflictSpeaker({
+                id: "sn-1",
+                source: "manual",
+                displayName: "Alice",
+            }),
+        ).toEqual({ action: "skip", displayName: "Alice" });
+    });
+
+    it("retries a guarded update when the winner is not manual", () => {
+        expect(
+            classifyConflictSpeaker({
+                id: "sn-2",
+                source: "auto",
+                displayName: "Alice",
+            }),
+        ).toEqual({
+            action: "update",
+            id: "sn-2",
+            displayName: "Alice",
+        });
+    });
+
+    it("ignores a vanished row", () => {
+        expect(classifyConflictSpeaker(undefined)).toEqual({ action: "none" });
+    });
+});

--- a/src/tests/regressions/268-speaker-rename-rollback.test.ts
+++ b/src/tests/regressions/268-speaker-rename-rollback.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Regression for #268 Greptile P1: a failed optimistic rename A must
+ * not wipe a successful rename B. Rollback is scoped to one label and
+ * ignored when a newer edit owns that same label.
+ */
+
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { toast } from "sonner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useSpeakerNames } from "@/hooks/use-speaker-names";
+import {
+    nextSpeakerEditGeneration,
+    rollbackSpeakerName,
+    shouldApplySpeakerEdit,
+} from "@/lib/speakers/rename-state";
+import type { SpeakerName, SpeakerNameMap } from "@/types/speaker";
+
+vi.mock("sonner", () => ({
+    toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+        warning: vi.fn(),
+    },
+}));
+
+type PendingRequest = {
+    url: string;
+    method: string;
+    resolve: (value: Response) => void;
+    reject: (reason?: unknown) => void;
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+function name(
+    speakerLabel: string,
+    displayName: string,
+    source: SpeakerName["source"] = "manual",
+): SpeakerName {
+    return {
+        speakerLabel,
+        displayName,
+        source,
+        confidence: null,
+        voiceProfileId: null,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+}
+
+let pending: PendingRequest[] = [];
+
+beforeEach(() => {
+    pending = [];
+    vi.mocked(toast.error).mockClear();
+    vi.stubGlobal("fetch", (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = (init?.method ?? "GET").toUpperCase();
+        return new Promise<Response>((resolve, reject) => {
+            pending.push({ url, method, resolve, reject });
+        });
+    });
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+function takePending(method: string): PendingRequest {
+    const idx = pending.findIndex((p) => p.method === method);
+    if (idx < 0) {
+        throw new Error(`missing ${method}: ${JSON.stringify(pending)}`);
+    }
+    const [req] = pending.splice(idx, 1);
+    return req;
+}
+
+async function flush(): Promise<void> {
+    await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+describe("rollbackSpeakerName", () => {
+    const alice = name("SPEAKER_00", "Alice");
+    const bob = name("SPEAKER_01", "Bob");
+    const map: SpeakerNameMap = {
+        SPEAKER_00: alice,
+        SPEAKER_01: bob,
+    };
+
+    it("restores only the failed label", () => {
+        expect(
+            rollbackSpeakerName(map, "SPEAKER_00", name("SPEAKER_00", "Old")),
+        ).toEqual({
+            SPEAKER_00: name("SPEAKER_00", "Old"),
+            SPEAKER_01: bob,
+        });
+    });
+
+    it("drops only the failed label when there was no prior name", () => {
+        expect(rollbackSpeakerName(map, "SPEAKER_00", undefined)).toEqual({
+            SPEAKER_01: bob,
+        });
+    });
+});
+
+describe("shouldApplySpeakerEdit", () => {
+    it("rejects a stale generation after a newer edit of the same label", () => {
+        const gens = new Map<string, number>();
+        const first = nextSpeakerEditGeneration(gens, "SPEAKER_00");
+        const second = nextSpeakerEditGeneration(gens, "SPEAKER_00");
+        expect(shouldApplySpeakerEdit(gens, "SPEAKER_00", first)).toBe(false);
+        expect(shouldApplySpeakerEdit(gens, "SPEAKER_00", second)).toBe(true);
+        expect(shouldApplySpeakerEdit(gens, "SPEAKER_01", 1)).toBe(false);
+    });
+});
+
+describe("useSpeakerNames overlapping rename rollback", () => {
+    it("keeps B when A fails", async () => {
+        const hook = renderHook(() => useSpeakerNames("rec-1"));
+        await flush();
+        takePending("GET").resolve(jsonResponse({ speakers: [] }));
+        await flush();
+
+        let renameA!: Promise<void>;
+        act(() => {
+            renameA = hook.result.current.renameSpeaker("SPEAKER_00", "Alice");
+        });
+        await flush();
+        const putA = takePending("PUT");
+
+        let renameB!: Promise<void>;
+        act(() => {
+            renameB = hook.result.current.renameSpeaker("SPEAKER_01", "Bob");
+        });
+        await flush();
+        const putB = takePending("PUT");
+
+        putB.resolve(jsonResponse({ speaker: name("SPEAKER_01", "Bob") }));
+        await renameB;
+        await flush();
+
+        expect(hook.result.current.speakerNames.SPEAKER_01?.displayName).toBe(
+            "Bob",
+        );
+
+        putA.resolve(jsonResponse({ error: "nope" }, 500));
+        await renameA;
+        await flush();
+
+        expect(hook.result.current.speakerNames.SPEAKER_00).toBeUndefined();
+        expect(hook.result.current.speakerNames.SPEAKER_01?.displayName).toBe(
+            "Bob",
+        );
+        expect(toast.error).toHaveBeenCalledWith("Failed to rename speaker");
+    });
+
+    it("does not restore a stale snapshot over a newer edit of the same label", async () => {
+        const hook = renderHook(() => useSpeakerNames("rec-1"));
+        await flush();
+        takePending("GET").resolve(jsonResponse({ speakers: [] }));
+        await flush();
+
+        let renameA!: Promise<void>;
+        act(() => {
+            renameA = hook.result.current.renameSpeaker("SPEAKER_00", "Alice");
+        });
+        await flush();
+        const putA = takePending("PUT");
+
+        let renameB!: Promise<void>;
+        act(() => {
+            renameB = hook.result.current.renameSpeaker("SPEAKER_00", "Alicia");
+        });
+        await flush();
+        const putB = takePending("PUT");
+
+        putB.resolve(jsonResponse({ speaker: name("SPEAKER_00", "Alicia") }));
+        await renameB;
+        await flush();
+
+        putA.resolve(jsonResponse({ error: "nope" }, 500));
+        await renameA;
+        await flush();
+
+        expect(hook.result.current.speakerNames.SPEAKER_00?.displayName).toBe(
+            "Alicia",
+        );
+    });
+});

--- a/src/tests/speaker-embeddings.test.ts
+++ b/src/tests/speaker-embeddings.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+    cosineSimilarity,
+    EMBEDDING_DIMENSIONS,
+    isEmbedding,
+    mergeCentroid,
+    normalizeEmbedding,
+    parseEmbedding,
+    toStoredEmbedding,
+} from "../lib/speakers/embeddings";
+
+/** A deterministic unit-ish vector of the required width. */
+function vector(fn: (i: number) => number): number[] {
+    return Array.from({ length: EMBEDDING_DIMENSIONS }, (_, i) => fn(i));
+}
+
+const ONES = vector(() => 1);
+const RAMP = vector((i) => i + 1);
+
+describe("isEmbedding", () => {
+    it("accepts a finite, non-zero vector of the exact width", () => {
+        expect(isEmbedding(ONES)).toBe(true);
+        expect(isEmbedding(RAMP)).toBe(true);
+    });
+
+    it("rejects wrong widths, non-arrays and non-numbers", () => {
+        expect(isEmbedding(vector(() => 1).slice(1))).toBe(false);
+        expect(isEmbedding([...ONES, 1])).toBe(false);
+        expect(isEmbedding("nope")).toBe(false);
+        expect(isEmbedding(null)).toBe(false);
+        expect(isEmbedding(vector((i) => (i === 3 ? Number.NaN : 1)))).toBe(
+            false,
+        );
+        expect(
+            isEmbedding(
+                vector((i) => (i === 3 ? Number.POSITIVE_INFINITY : 1)),
+            ),
+        ).toBe(false);
+    });
+
+    it("rejects a zero vector, which has no direction to match on", () => {
+        expect(isEmbedding(vector(() => 0))).toBe(false);
+    });
+});
+
+describe("parseEmbedding", () => {
+    it("returns the vector when valid", () => {
+        expect(parseEmbedding(ONES)).toEqual(ONES);
+    });
+
+    it("names the offending field in the error message", () => {
+        expect(() =>
+            parseEmbedding([1, 2, 3], "embeddings.SPEAKER_00"),
+        ).toThrow(
+            /embeddings\.SPEAKER_00 must contain exactly 256 numbers, received 3/,
+        );
+    });
+
+    it("rejects non-arrays, non-finite entries and zero vectors", () => {
+        expect(() => parseEmbedding("nope")).toThrow(/must be an array/);
+        expect(() =>
+            parseEmbedding(vector((i) => (i === 0 ? Number.NaN : 1))),
+        ).toThrow(/finite numbers/);
+        expect(() => parseEmbedding(vector(() => 0))).toThrow(/zero vector/);
+    });
+});
+
+describe("normalizeEmbedding", () => {
+    it("scales to unit length", () => {
+        const unit = normalizeEmbedding(RAMP);
+        const magnitude = Math.sqrt(
+            unit.reduce((sum, value) => sum + value * value, 0),
+        );
+        expect(magnitude).toBeCloseTo(1, 10);
+    });
+
+    it("returns a zero vector unchanged rather than dividing by zero", () => {
+        const zero = vector(() => 0);
+        expect(normalizeEmbedding(zero)).toEqual(zero);
+    });
+});
+
+describe("toStoredEmbedding", () => {
+    it("is unit length and rounded to six decimals", () => {
+        const stored = toStoredEmbedding(RAMP);
+        const magnitude = Math.sqrt(
+            stored.reduce((sum, value) => sum + value * value, 0),
+        );
+        expect(magnitude).toBeCloseTo(1, 5);
+        for (const value of stored) {
+            expect(value).toBe(Math.round(value * 1e6) / 1e6);
+        }
+    });
+
+    it("round-trips through isEmbedding", () => {
+        expect(isEmbedding(toStoredEmbedding(RAMP))).toBe(true);
+    });
+});
+
+describe("cosineSimilarity", () => {
+    it("is 1 for identical directions regardless of magnitude", () => {
+        expect(cosineSimilarity(ONES, ONES)).toBeCloseTo(1, 10);
+        expect(
+            cosineSimilarity(
+                ONES,
+                ONES.map((v) => v * 17),
+            ),
+        ).toBeCloseTo(1, 10);
+    });
+
+    it("is -1 for opposed directions", () => {
+        expect(
+            cosineSimilarity(
+                RAMP,
+                RAMP.map((v) => -v),
+            ),
+        ).toBeCloseTo(-1, 10);
+    });
+
+    it("is 0 for orthogonal vectors", () => {
+        const a = vector((i) => (i % 2 === 0 ? 1 : 0));
+        const b = vector((i) => (i % 2 === 0 ? 0 : 1));
+        expect(cosineSimilarity(a, b)).toBe(0);
+    });
+
+    it("returns 0 rather than NaN for mismatched or zero-magnitude input", () => {
+        expect(cosineSimilarity(ONES, [1, 2, 3])).toBe(0);
+        expect(cosineSimilarity([], [])).toBe(0);
+        expect(
+            cosineSimilarity(
+                ONES,
+                vector(() => 0),
+            ),
+        ).toBe(0);
+    });
+});
+
+describe("mergeCentroid", () => {
+    it("leaves the centroid alone when the sample matches it", () => {
+        const centroid = toStoredEmbedding(RAMP);
+        const merged = mergeCentroid(centroid, 4, RAMP);
+        expect(cosineSimilarity(merged, centroid)).toBeCloseTo(1, 6);
+    });
+
+    it("moves toward a new sample, and less so as sampleCount grows", () => {
+        const centroid = toStoredEmbedding(ONES);
+        const sample = vector((i) => (i % 2 === 0 ? 1 : -1));
+
+        const afterOne = mergeCentroid(centroid, 1, sample);
+        const afterMany = mergeCentroid(centroid, 50, sample);
+
+        // Both drift toward the sample, but the established profile drifts less.
+        expect(cosineSimilarity(afterOne, sample)).toBeGreaterThan(
+            cosineSimilarity(centroid, sample),
+        );
+        expect(cosineSimilarity(afterMany, sample)).toBeLessThan(
+            cosineSimilarity(afterOne, sample),
+        );
+        expect(cosineSimilarity(afterMany, centroid)).toBeGreaterThan(
+            cosineSimilarity(afterOne, centroid),
+        );
+    });
+
+    it("ignores sample magnitude, so a loud sample cannot dominate", () => {
+        const centroid = toStoredEmbedding(ONES);
+        const sample = vector((i) => (i % 2 === 0 ? 1 : -1));
+        const loud = sample.map((v) => v * 1000);
+
+        const quiet = mergeCentroid(centroid, 3, sample);
+        const shouted = mergeCentroid(centroid, 3, loud);
+        expect(cosineSimilarity(quiet, shouted)).toBeCloseTo(1, 6);
+    });
+
+    it("treats a sampleCount below 1 as 1", () => {
+        const centroid = toStoredEmbedding(ONES);
+        const sample = vector((i) => (i % 2 === 0 ? 1 : -1));
+        expect(mergeCentroid(centroid, 0, sample)).toEqual(
+            mergeCentroid(centroid, 1, sample),
+        );
+    });
+
+    it("produces a vector that is still storable", () => {
+        const merged = mergeCentroid(toStoredEmbedding(ONES), 2, RAMP);
+        expect(isEmbedding(merged)).toBe(true);
+    });
+});

--- a/src/types/speaker.ts
+++ b/src/types/speaker.ts
@@ -1,0 +1,63 @@
+import type { InferSelectModel } from "drizzle-orm";
+import type { speakerNames, voiceProfiles } from "@/db/schema";
+
+export type SpeakerNameRow = InferSelectModel<typeof speakerNames>;
+export type VoiceProfileRow = InferSelectModel<typeof voiceProfiles>;
+
+/** How a speaker got its name: typed by the user, or matched by voice. */
+export type SpeakerNameSource = "manual" | "auto";
+
+/** One diarized speaker label mapped to a human name, over the wire. */
+export interface SpeakerName {
+    speakerLabel: string;
+    displayName: string;
+    source: SpeakerNameSource;
+    /** Cosine similarity of the voice match; null for manual names. */
+    confidence: number | null;
+    voiceProfileId: string | null;
+    updatedAt: string;
+}
+
+/** Speaker names for one recording, keyed by raw transcript label. */
+export type SpeakerNameMap = Record<string, SpeakerName>;
+
+/** A known voice, without the embedding (too bulky for list responses). */
+export interface VoiceProfileSummary {
+    id: string;
+    displayName: string;
+    sampleCount: number;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export function serializeSpeakerName(row: SpeakerNameRow): SpeakerName {
+    return {
+        speakerLabel: row.speakerLabel,
+        displayName: row.displayName,
+        // Column is a plain varchar, so anything unexpected in the DB
+        // degrades to the conservative 'manual' reading rather than
+        // widening the client-facing union.
+        source: row.source === "auto" ? "auto" : "manual",
+        confidence: row.confidence ?? null,
+        voiceProfileId: row.voiceProfileId ?? null,
+        updatedAt: row.updatedAt.toISOString(),
+    };
+}
+
+export function indexSpeakerNames(names: SpeakerName[]): SpeakerNameMap {
+    const map: SpeakerNameMap = {};
+    for (const name of names) map[name.speakerLabel] = name;
+    return map;
+}
+
+export function serializeVoiceProfile(
+    row: Omit<VoiceProfileRow, "embedding" | "userId">,
+): VoiceProfileSummary {
+    return {
+        id: row.id,
+        displayName: row.displayName,
+        sampleCount: row.sampleCount,
+        createdAt: row.createdAt.toISOString(),
+        updatedAt: row.updatedAt.toISOString(),
+    };
+}


### PR DESCRIPTION
Draft on purpose, for two reasons: CONTRIBUTING asks for discussion before a change this size, and #230 explicitly put cross-recording voice identification out of scope, so the second half of this needs your agreement before it is worth reviewing line by line. Proposal and the design arguments are in #267.

Closes #267 if you want it. Related: #230, and stacked on #265.

## Stacking

This branch contains **two** commits. The first is #265 unchanged, because the speaker chips are additions to `rich-content.tsx` and `transcription-panel.tsx` that #265 introduces. Review the second commit (`feat(speakers): ...`) for this PR. If #265 lands first this rebases to a single commit; if you would rather it did not depend on #265 at all, say so and I will inline what it needs.

## Why

Diarization gives you `SPEAKER_00` / `SPEAKER_01`, and the numbering is not stable between recordings. On `main` there is no way to name a speaker at all, and for anyone recording the same handful of people every week there would be no way to avoid retyping the same names on every recording. Full argument in #267.

## What this does

**`speaker_names`** maps `(recording_id, speaker_label)` to a display name, unique on that pair, user-scoped, cascading from both `users` and `recordings`. The transcript text is never rewritten: the label stays the stable key and the name is a display layer, so a rename cannot corrupt a transcript, clearing the row returns the raw label, and colours (assigned from the raw label) survive a rename. Routes: `GET`, `PUT`, `DELETE /api/recordings/:id/speakers`.

**`voice_profiles`** holds one centroid per known person per user plus a sample count. `GET`/`POST /api/voice-profiles` lists and creates-or-extends. `POST /api/recordings/:id/speakers/match` cosine-matches a recording's speakers against that user's profiles and auto-names the ones clearing `SPEAKER_MATCH_THRESHOLD` (0.75), reporting near-misses under `unmatched` and hand-named speakers under `skipped` without writing anything for either.

**UI**: each speaker label in the transcript becomes a click-to-edit chip. Enter saves, Escape cancels, empty clears. Auto-matched names carry an `auto` badge with the similarity in the tooltip. Writes are optimistic and roll back on failure. Without `onRenameSpeaker` the labels render read-only, which is how #265 leaves them.

## Deliberate design choices

- **Embeddings come from outside Riffado.** The API accepts vectors, it does not produce them. No model, no ONNX runtime, no Python sidecar, no cloud dependency, and the local-AI path is untouched. The honest cost: until something in-tree produces embeddings, the voice-matching half is a building block for people wiring up pyannote / WhisperX / Speaches themselves, not a turnkey feature. Per-recording naming works with nothing extra.
- **`jsonb`, not `pgvector`.** The candidate set is one user's own profiles, so matching in application code is fine, and the schema still runs on the stock `postgres:16` image `docker-compose.yml` ships. No extension for self-hosters to install.
- **Manual always wins.** A hand-typed name is `source = 'manual'` and the matcher never overwrites it. Enforced at the write with a `source <> 'manual'` predicate inside the same transaction as the locking read, not just by the earlier branch, so a rename landing mid-match cannot be clobbered.
- **Additive schema.** Two new tables, nothing altered or dropped.

## Multi-tenant and hosted checks

- Every speaker route calls `assertRecordingOwned` (`id`, `userId`, `isNull(deletedAt)`) before touching `speaker_names`, so a recording id from the URL cannot reach another user's rows. Every profile query filters on `userId`.
- Speaker labels are validated against an anchored pattern, so a payload cannot introduce a key like `__proto__` into the label-keyed maps the client builds.
- Both write paths use `SELECT ... FOR UPDATE` inside a transaction rather than an in-memory guard, so nothing here depends on being single-process.
- Match requests are capped at 64 labels and embeddings at a fixed width, so one request cannot ask the server to do unbounded work.
- No secrets involved, so nothing new goes through `encryption.ts`.

## Migrations

`0036_youthful_slayback.sql` plus its snapshot and journal entry are `pnpm db:generate` output against the edited `schema.ts`. Nothing in `meta/` is hand-written. Note that #228 also claims `0036`; whichever lands first, I will regenerate rather than renumber by hand.

## Known gaps

Flagging these rather than pretending they are done:

- **Export parity.** `build-archive.ts` does not include `speaker_names` or `voice_profiles`, so speaker names do not currently round-trip through a backup. That has to change before this is really finished. I left it out to keep the diff reviewable, and I would rather agree the archive format change with you than guess it.
- **No settings UI for voice profiles.** They are API-only: no list, no rename, no delete outside of deleting the account. A voice profile is biometric-adjacent, so it probably deserves its own control, and that is a question about product surface more than code.
- **Relationship to #230.** This keys names on labels parsed from transcript text. If you land the structured segment model first, the label still exists and `speaker_names` still works, but you may prefer to key on segment speaker ids instead. Worth deciding before this merges.
- **`transcription-panel.tsx` is also touched by #210**, so there may be a trivial rebase.

## Testing

- `pnpm format-and-lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` all pass on this branch. New routes appear in the build manifest.
- `src/tests/speaker-embeddings.test.ts` adds 19 tests over the embedding maths: validation and rejection cases for width, non-finite entries and zero vectors, cosine similarity at 1 / -1 / 0 and its zero fallback on mismatched input, and centroid merging (drifts toward a new sample, drifts less as `sampleCount` grows, and is unaffected by sample magnitude). Suite goes from 822 to 841 passing.
- The naming half has been exercised against real diarized Plaud transcripts in a self-hosted deployment: rename, clear, reload, and switching transcript source.
- **The voice-matching half is much less well tested.** The maths is unit-tested and the routes have been exercised with hand-fed embeddings, but I have not run it over a real embedding pipeline at any scale, so I have no honest claim about how well 0.75 separates real speakers. Treat that threshold as a starting guess.
- No integration tests over the routes themselves. Happy to add them if you point me at the pattern you want.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds user-scoped speaker naming, optional cross-recording voice matching, and improved transcript/summary rendering. You can rename diarized labels, auto-fill known voices via embeddings, and read Plaud markdown with safe links and images.

- **New Features**
  - API: `GET/PUT/DELETE /api/recordings/:id/speakers` to list, name, and clear; `POST /api/recordings/:id/speakers/match` to auto-name via cosine match; `GET/POST /api/voice-profiles` to list and create/extend profiles.
  - UI: transcript renders by speaker with editable chips (Enter saves, Escape cancels, empty clears); auto-named chips show an "auto" badge with confidence; non-diarized transcripts fall back to plain text; summaries render as markdown (headings, lists, links, images) and ordered lists keep numbers.
  - Matching: embeddings are supplied by the caller; threshold is 0.75; manual names always win and are never overwritten. Failed optimistic renames revert only that speaker, and a match that loses a race to a manual rename skips it instead of aborting the batch.
  - Storage/perf/security: embeddings stored as `jsonb` (no `pgvector`); matching done in app code; strict ownership checks, label validation, and request caps; markdown links restricted to https or same-origin paths (protocol-relative rejected) and images to https or same-origin assets.

- **Migration**
  - Run DB migrations to add `speaker_names` and `voice_profiles`.
  - No new services or model runtimes required; manual naming works without embeddings.
  - To enable auto-naming, POST normalized speaker embeddings to `/api/voice-profiles` (to build profiles) and then `/api/recordings/:id/speakers/match`.

<sup>Written for commit 4c572606cbb6975dc06dfae58bc399d256a6b8de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

