### PR TITLE
feat(plaud): support China mainland region (plaud.cn)

### DIFF
--- a/src/components/plaud-connect-tabs.tsx
+++ b/src/components/plaud-connect-tabs.tsx
@@ -51,6 +51,7 @@ const TOKEN_GRAB_SNIPPET =
 function regionLabel(base: string): string {
     if (base.includes("euc1")) return "EU (Frankfurt)";
     if (base.includes("apse1")) return "Asia Pacific (Singapore)";
+    if (base.includes("api.plaud.cn")) return "China Mainland";
     if (base.includes("api.plaud.ai")) return "Global";
     return base;
 }

--- a/src/components/settings-sections/plaud-account-section.tsx
+++ b/src/components/settings-sections/plaud-account-section.tsx
@@ -42,6 +42,7 @@ function regionLabel(
     if (server === "global") return "Global";
     if (server === "eu") return "EU (Frankfurt)";
     if (server === "apse1") return "Asia Pacific (Singapore)";
+    if (server === "cn") return "China Mainland";
     return server;
 }
 

--- a/src/lib/plaud/proxy.ts
+++ b/src/lib/plaud/proxy.ts
@@ -81,7 +81,11 @@ export function shouldProxyPlaud(url: string): boolean {
         const u = new URL(url);
         if (u.protocol !== "https:") return false;
         const h = u.hostname.toLowerCase();
-        const isPlaud = h === "plaud.ai" || h.endsWith(".plaud.ai");
+        const isPlaud =
+            h === "plaud.ai" ||
+            h.endsWith(".plaud.ai") ||
+            h === "plaud.cn" ||
+            h.endsWith(".plaud.cn");
         if (!isPlaud) return false;
         if (env.PLAUD_PROXY_SCOPE === "api-only" && h === "resource.plaud.ai") {
             return false;

--- a/src/lib/plaud/proxy.ts
+++ b/src/lib/plaud/proxy.ts
@@ -75,6 +75,11 @@ async function fetchProxyList(): Promise<WebshareProxy[]> {
     }
 }
 
+const PLAUD_RESOURCE_HOSTS = new Set([
+    "resource.plaud.ai",
+    "resource.plaud.cn",
+]);
+
 /** Whether `url` should route through the Plaud proxy. */
 export function shouldProxyPlaud(url: string): boolean {
     try {
@@ -87,7 +92,10 @@ export function shouldProxyPlaud(url: string): boolean {
             h === "plaud.cn" ||
             h.endsWith(".plaud.cn");
         if (!isPlaud) return false;
-        if (env.PLAUD_PROXY_SCOPE === "api-only" && h === "resource.plaud.ai") {
+        if (
+            env.PLAUD_PROXY_SCOPE === "api-only" &&
+            PLAUD_RESOURCE_HOSTS.has(h)
+        ) {
             return false;
         }
         return true;

--- a/src/lib/plaud/servers.ts
+++ b/src/lib/plaud/servers.ts
@@ -19,6 +19,12 @@ export const PLAUD_SERVERS = {
             "Asia Pacific server — used by APAC accounts (api-apse1.plaud.ai)",
         apiBase: "https://api-apse1.plaud.ai",
     },
+    cn: {
+        label: "China Mainland (api.plaud.cn)",
+        description:
+            "China mainland server — used by accounts registered on web.plaud.cn / app.plaud.cn (api.plaud.cn)",
+        apiBase: "https://api.plaud.cn",
+    },
     custom: {
         label: "Custom",
         description:
@@ -30,14 +36,27 @@ export const PLAUD_SERVERS = {
 export type PlaudServerKey = keyof typeof PLAUD_SERVERS;
 export const DEFAULT_SERVER_KEY: PlaudServerKey = "global";
 
-/** HTTPS + plaud.ai-subdomain check. */
+/**
+ * HTTPS + Plaud-domain check.
+ *
+ * Accepts both `plaud.ai` (global / EU / APAC) and `plaud.cn` (China
+ * mainland). Plaud runs a region-separated China deployment on
+ * `api.plaud.cn` / `web.plaud.cn`; accounts registered there do not exist
+ * on the `.ai` side at all, so a `.cn` account cannot connect unless this
+ * gate admits the domain. The `.cn` deployment is the same backend --
+ * `POST /auth/otp-send-code` returns a byte-identical pydantic validation
+ * envelope on both hosts -- so no other code path needs to branch on region.
+ */
 export function isValidPlaudApiUrl(url: string): boolean {
     try {
         const parsed = new URL(url);
+        if (parsed.protocol !== "https:") return false;
+        const host = parsed.hostname;
         return (
-            parsed.protocol === "https:" &&
-            (parsed.hostname === "plaud.ai" ||
-                parsed.hostname.endsWith(".plaud.ai"))
+            host === "plaud.ai" ||
+            host.endsWith(".plaud.ai") ||
+            host === "plaud.cn" ||
+            host.endsWith(".plaud.cn")
         );
     } catch {
         return false;

--- a/src/lib/plaud/workspace.ts
+++ b/src/lib/plaud/workspace.ts
@@ -13,7 +13,9 @@ function safePlaudUrl(apiBase: string, path: string): URL {
     if (
         parsed.protocol !== "https:" ||
         (parsed.hostname !== "plaud.ai" &&
-            !parsed.hostname.endsWith(".plaud.ai"))
+            !parsed.hostname.endsWith(".plaud.ai") &&
+            parsed.hostname !== "plaud.cn" &&
+            !parsed.hostname.endsWith(".plaud.cn"))
     ) {
         throw new AppError(
             ErrorCode.PLAUD_INVALID_API_BASE,

--- a/src/tests/plaud-proxy.test.ts
+++ b/src/tests/plaud-proxy.test.ts
@@ -87,24 +87,36 @@ describe("shouldProxyPlaud", () => {
         expect(shouldProxyPlaud("https://resource.plaud.ai/foo")).toBe(true);
         expect(shouldProxyPlaud("https://plaud.ai/")).toBe(true);
         expect(shouldProxyPlaud("https://api.plaud.cn/foo")).toBe(true);
+        expect(shouldProxyPlaud("https://resource.plaud.cn/foo")).toBe(true);
         expect(shouldProxyPlaud("https://plaud.cn/")).toBe(true);
     });
 
     it("rejects non-Plaud, http, and malformed URLs", () => {
         expect(shouldProxyPlaud("https://example.com/")).toBe(false);
         expect(shouldProxyPlaud("https://plaud.ai.evil.com/")).toBe(false);
+        expect(shouldProxyPlaud("https://notplaud.ai/")).toBe(false);
         expect(shouldProxyPlaud("http://api.plaud.ai/")).toBe(false);
         expect(shouldProxyPlaud("not-a-url")).toBe(false);
         expect(shouldProxyPlaud("https://plaud.cn.evil.com/")).toBe(false);
+        expect(shouldProxyPlaud("https://notplaud.cn/")).toBe(false);
+        expect(
+            shouldProxyPlaud("https://resource.plaud.cn.evil.com/audio.mp3"),
+        ).toBe(false);
     });
 
-    it("skips resource.plaud.ai when PLAUD_PROXY_SCOPE=api-only", () => {
+    it("skips .ai and .cn resource hosts when PLAUD_PROXY_SCOPE=api-only", () => {
         mockEnv.PLAUD_PROXY_SCOPE = "api-only";
         expect(shouldProxyPlaud("https://api.plaud.ai/foo")).toBe(true);
         expect(shouldProxyPlaud("https://api-euc1.plaud.ai/foo")).toBe(true);
-        expect(shouldProxyPlaud("https://resource.plaud.ai/file.mp3")).toBe(
+        expect(shouldProxyPlaud("https://api.plaud.cn/foo")).toBe(true);
+        expect(shouldProxyPlaud("https://resource.plaud.ai/audio.mp3")).toBe(
             false,
         );
+        expect(shouldProxyPlaud("https://resource.plaud.cn/audio.mp3")).toBe(
+            false,
+        );
+        expect(shouldProxyPlaud("https://plaud.ai.evil.com/")).toBe(false);
+        expect(shouldProxyPlaud("https://plaud.cn.evil.com/")).toBe(false);
     });
 });
 

--- a/src/tests/plaud-proxy.test.ts
+++ b/src/tests/plaud-proxy.test.ts
@@ -86,6 +86,8 @@ describe("shouldProxyPlaud", () => {
         expect(shouldProxyPlaud("https://api-apse1.plaud.ai/foo")).toBe(true);
         expect(shouldProxyPlaud("https://resource.plaud.ai/foo")).toBe(true);
         expect(shouldProxyPlaud("https://plaud.ai/")).toBe(true);
+        expect(shouldProxyPlaud("https://api.plaud.cn/foo")).toBe(true);
+        expect(shouldProxyPlaud("https://plaud.cn/")).toBe(true);
     });
 
     it("rejects non-Plaud, http, and malformed URLs", () => {
@@ -93,6 +95,7 @@ describe("shouldProxyPlaud", () => {
         expect(shouldProxyPlaud("https://plaud.ai.evil.com/")).toBe(false);
         expect(shouldProxyPlaud("http://api.plaud.ai/")).toBe(false);
         expect(shouldProxyPlaud("not-a-url")).toBe(false);
+        expect(shouldProxyPlaud("https://plaud.cn.evil.com/")).toBe(false);
     });
 
     it("skips resource.plaud.ai when PLAUD_PROXY_SCOPE=api-only", () => {

--- a/src/tests/plaud.test.ts
+++ b/src/tests/plaud.test.ts
@@ -316,6 +316,9 @@ describe("PlaudClient", () => {
             expect(serverKeyFromApiBase("https://api-apse1.plaud.ai")).toBe(
                 "apse1",
             );
+            // Resolving to 'cn' (not 'custom') is what makes the settings
+            // page render a readable region label instead of the raw base URL.
+            expect(serverKeyFromApiBase("https://api.plaud.cn")).toBe("cn");
         });
 
         it("should return 'custom' for unknown URLs", () => {

--- a/src/tests/plaud.test.ts
+++ b/src/tests/plaud.test.ts
@@ -279,10 +279,22 @@ describe("PlaudClient", () => {
             expect(isValidPlaudApiUrl("https://api-usw1.plaud.ai")).toBe(true);
         });
 
+        // Plaud runs a region-separated China deployment; accounts created
+        // on web.plaud.cn do not exist on the .ai side, so the gate has to
+        // admit .cn or those users can never connect at all.
+        it("should accept valid plaud.cn HTTPS URLs (China mainland)", () => {
+            expect(isValidPlaudApiUrl("https://api.plaud.cn")).toBe(true);
+            expect(isValidPlaudApiUrl("https://web.plaud.cn")).toBe(true);
+            expect(isValidPlaudApiUrl("https://plaud.cn")).toBe(true);
+        });
+
         it("should reject non-plaud domains", () => {
             expect(isValidPlaudApiUrl("https://evil.com")).toBe(false);
             expect(isValidPlaudApiUrl("https://plaud.ai.evil.com")).toBe(false);
             expect(isValidPlaudApiUrl("https://notplaud.ai")).toBe(false);
+            // Same look-alike traps for the .cn domain.
+            expect(isValidPlaudApiUrl("https://plaud.cn.evil.com")).toBe(false);
+            expect(isValidPlaudApiUrl("https://notplaud.cn")).toBe(false);
         });
 
         it("should reject non-HTTPS URLs", () => {


### PR DESCRIPTION
## Problem

Plaud runs a region-separated China mainland deployment on `plaud.cn`
(`web.plaud.cn` / `app.plaud.cn` / `api.plaud.cn`). Accounts registered there
do not exist on the `.ai` side at all — the regions are separate account
systems, with official migration only via `migrate.plaud.cn`.

Today those users cannot connect at all. All three connect paths funnel
through hostname gates that only admit `*.plaud.ai`, so even the existing
**Custom** server option in the paste-token UI is rejected:

- `isValidPlaudApiUrl()` — used by `/api/plaud/auth/verify` and
  `/api/plaud/auth/connect-token`
- `safePlaudUrl()` in `workspace.ts`
- `shouldProxyPlaud()` in `proxy.ts`

## Evidence the `.cn` deployment is the same backend

Not a separate implementation — `POST /auth/otp-send-code` returns a
byte-identical pydantic validation envelope on both hosts:

```
api.plaud.ai → {"detail":[{"type":"missing","loc":["body","username"],...}]}  HTTP 422
api.plaud.cn → {"detail":[{"type":"missing","loc":["body","username"],...}]}  HTTP 422
```

So no code path needs to branch on region — only the domain gates need to
admit `.cn`. This mirrors how the existing regions are handled (cf. #202,
which added APNE1).

## Changes

- `servers.ts` — add a `cn` server preset; `isValidPlaudApiUrl` accepts
  `plaud.cn` / `*.plaud.cn` alongside the `.ai` hosts
- `workspace.ts` — same widening in the inlined SSRF sanitiser (kept inlined
  so CodeQL still recognises it, per the existing comment)
- `proxy.ts` — `shouldProxyPlaud` treats `.cn` as a Plaud host

Look-alike rejection is preserved and now covered by tests for **both**
domains: `plaud.ai.evil.com`, `plaud.cn.evil.com`, `notplaud.ai`,
`notplaud.cn` all still rejected.

## Verification

- `pnpm test` — 863 passed / 10 skipped
- `pnpm type-check` clean; `biome check` on the changed files clean
  (the 2 pre-existing infos are unchanged from `main`)
- **Verified end-to-end against a real China-region account** on a
  self-hosted instance built from this branch: paste-token connect with the
  new `cn` preset → workspace resolution → device list → recording sync, all
  succeed unchanged. Recordings downloaded to local storage and filenames
  decrypt correctly.

## Notes / scope

- This is the **server side**. The paste-token path works with it today
  (the `pld_ut` cookie is readable from DevTools on `web.plaud.cn`).
- The connector extension would additionally need `web.plaud.cn` /
  `api.plaud.cn` in `host_permissions` plus a region mapping for its
  bridge flow — happy to open a matching PR on `riffado/connector` if
  this direction is welcome.
- The email-OTP path still starts at `api.plaud.ai` and has no server
  selector in the UI, so it remains `.ai`-only. Left out deliberately to
  keep this PR minimal; can follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow China mainland accounts to connect by accepting `plaud.cn` hosts. Previously `.cn` URLs were rejected; now HTTPS `plaud.cn` and subdomains are allowed, enabling connect and sync. Security gates remain strict and continue to block look‑alikes.

- Add `cn` server preset (`https://api.plaud.cn`); `serverKeyFromApiBase('https://api.plaud.cn')` resolves to `cn`, and UI shows “China Mainland” in connect and settings.
- Extend `isValidPlaudApiUrl`, `safePlaudUrl`, and `shouldProxyPlaud` to accept `plaud.cn` and subdomains (HTTPS only); reject `plaud.cn.evil.com`/`notplaud.cn`.
- `PLAUD_PROXY_SCOPE=api-only` now also bypasses `resource.plaud.cn`, so both regions download media directly.
- Tests cover `.cn` acceptance and look‑alike rejection; existing `.ai` regions behave unchanged.

<sup>Written for commit f1935d1d89deed4abf9dfbf3454499f5bcd7f634. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

