### PR TITLE
docs: add sponsor badge and Sponsors section to README

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# .github/FUNDING.yml
+github: riffado

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
-# .github/FUNDING.yml
 github: riffado

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 [![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://riffado.com/discord)
+[![Sponsor](https://img.shields.io/badge/sponsor-riffado-EA4AAA?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/riffado)
 
-[Quick start](#quick-start) • [Documentation](https://riffado.com/docs) • [Discord](https://riffado.com/discord)
+[Quick start](#quick-start) • [Documentation](https://riffado.com/docs) • [Discord](https://riffado.com/discord) • [Sponsor](https://github.com/sponsors/riffado)
 
 </div>
 
@@ -91,6 +92,20 @@ Everything lives at **[riffado.com/docs](https://riffado.com/docs)**. Direct lin
 - [Encryption at rest](https://riffado.com/docs/reference/encryption-at-rest)
 - [Security model](https://riffado.com/docs/reference/security-model)
 - [Architecture](https://riffado.com/docs/reference/architecture)
+
+## Sponsors
+
+Riffado is AGPL-3.0 and stays that way. Sponsorship is what pays for the parts
+that aren't fun: chasing vendor API changes that break sync, buying recorders to
+test new device support against, CI and registry costs, and the mobile app.
+
+[**Sponsor Riffado on GitHub &rarr;**](https://github.com/sponsors/riffado)
+
+If your team self-hosts Riffado at work, a company tier is the cheapest
+maintenance contract you'll ever buy.
+
+<!-- sponsors -->
+<!-- /sponsors -->
 
 ## Contributing
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,25 @@
+# Sponsors
+
+Riffado is free, AGPL-3.0, and self-hostable forever. It's kept alive by people
+who chip in.
+
+[**Become a sponsor →**](https://github.com/sponsors/riffado)
+
+## What sponsorship funds
+
+- The native mobile app, the largest item on the roadmap
+- Device support beyond the Plaud Note family, which means buying hardware to test against
+- Keeping sync working when vendor APIs change without notice
+- CI minutes, container registry, docs and demo hosting
+- Time on issues and pull requests
+
+## Current sponsors
+
+_No sponsors yet. This list updates as people join._
+
+<!-- sponsors -->
+<!-- /sponsors -->
+
+## Past sponsors
+
+_Thanks to everyone who has supported Riffado._


### PR DESCRIPTION
## Description

Adds GitHub Sponsors surfaces to `README.md`: a sponsor badge, a quick-link, and a
`## Sponsors` section explaining what sponsorship funds. Docs-only change.

## Type of Change

- [x] Documentation update

## Related Issues

None.

## Changes Made

- Added a `Sponsor` shields.io badge after the Discord badge in the centered header block.
- Added `Sponsor` to the quick-links line alongside Quick start / Documentation / Discord.
- Added a `## Sponsors` section directly above `## Contributing`, with a call to action and a note about company tiers for teams self-hosting at work.
- Included inert `<!-- sponsors -->` / `<!-- /sponsors -->` markers so a future `github-sponsors-readme-action` workflow can auto-insert sponsor avatars without hand-editing. No workflow is wired up in this PR.

## Testing

No code changed, so lint/type-check/test were not run.

### Test Steps
1. Render `README.md` on GitHub.
2. Confirm the sponsor badge and quick-link resolve to https://github.com/sponsors/riffado.
3. Confirm the `## Sponsors` section renders above `## Contributing` and the HTML comment markers stay invisible.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

## Database Changes

None.

## Breaking Changes

None.

## Additional Notes

`CHANGELOG.md` is intentionally untouched: it is maintainer-curated at release time,
and this is a README marketing surface rather than a self-host-facing change.

## For Reviewers

- Wording of the Sponsors section copy, in particular the "cheapest maintenance contract you'll ever buy" line.
- Whether the sponsors marker pair should land now or wait until the automation workflow is actually added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GitHub Sponsors surfaces: a sponsor badge and quick link in `README.md`, a new `## Sponsors` section with inert `<!-- sponsors -->` markers, a `SPONSORS.md` with rationale and the same markers, and `.github/FUNDING.yml` to enable the Sponsors button. Docs-only change.

<sup>Written for commit c4643cb5d2021f33655b75297939db95d898b4da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

