### PR TITLE
feat(recordings): download original audio and inline rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 - Custom summary prompts are now reachable from Settings → Summary: create, edit, view, and delete custom prompts, and select one as the default alongside the built-in presets. The per-recording summary dropdown also lists custom prompts and now initializes to the saved default instead of always defaulting to "General Summary" ([#199](https://github.com/riffado/riffado/issues/199)).
+- Download the original audio file from the recording player and the recording row menu (`GET /api/recordings/[id]/audio?download=1`) ([#229](https://github.com/riffado/riffado/issues/229)).
+- Inline rename for recording titles. Click the title in the player (or the recording page heading), edit, and press Enter. Persists via `PATCH /api/recordings/[id]` ([#217](https://github.com/riffado/riffado/issues/217)).
 
 ### Fixed
 - Changing the default summary prompt in Settings → Summary wiped any custom summary prompts on every save, since the request always sent `customPrompts: []` instead of the current list ([#199](https://github.com/riffado/riffado/issues/199)).

--- a/docs/API.md
+++ b/docs/API.md
@@ -207,14 +207,36 @@ Get single recording by ID.
 
 #### GET `/recordings/[id]/audio`
 
-Stream audio file.
+Stream audio file, or download the original when `download=1` is set.
+
+**Query Parameters:**
+- `download` (optional): `1` / `true` / `yes` returns `Content-Disposition: attachment` with a filename derived from the recording title and the stored file extension. Range requests are ignored so the saved file is complete.
 
 **Headers:**
-- `Range`: Optional byte range (e.g., `bytes=0-1023`)
+- `Range`: Optional byte range (e.g., `bytes=0-1023`). Ignored when `download` is set.
 
 **Response:**
-- Content-Type: audio/mpeg, audio/opus, etc.
-- Supports HTTP range requests (206 Partial Content)
+- Content-Type: audio/mpeg, audio/mp4, audio/wav, etc.
+- Supports HTTP range requests (206 Partial Content) for playback
+- `Content-Disposition: attachment` when downloading
+
+#### PATCH `/recordings/[id]`
+
+Rename a recording. The new title is encrypted at rest. Does not rename the file on Plaud.
+
+**Body:**
+```json
+{
+  "filename": "Q4 planning"
+}
+```
+
+**Response:**
+```json
+{
+  "filename": "Q4 planning"
+}
+```
 
 #### POST `/recordings/[id]/transcribe`
 

--- a/src/app/api/recordings/[id]/audio/route.ts
+++ b/src/app/api/recordings/[id]/audio/route.ts
@@ -3,8 +3,15 @@ import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { recordings } from "@/db/schema";
 import { requireApiSession } from "@/lib/auth-server";
+import { decryptText } from "@/lib/encryption/fields";
 import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import {
+    buildDownloadFilename,
+    contentDispositionAttachment,
+    isAudioDownloadRequest,
+} from "@/lib/recordings/filename";
 import { createUserStorageProvider } from "@/lib/storage/factory";
+import { getAudioMimeType } from "@/lib/utils";
 
 type IdContext = { params: Promise<{ id: string }> };
 
@@ -33,32 +40,32 @@ export const GET = apiHandler<IdContext>(async (request, context) => {
         );
     }
 
-    // Get storage provider
     const storage = await createUserStorageProvider(session.user.id);
-
-    // Download file
     const audioBuffer = await storage.downloadFile(recording.storagePath);
-
-    // Determine content type from file extension
-    const getContentType = (path: string): string => {
-        if (path.endsWith(".mp3")) return "audio/mpeg";
-        if (path.endsWith(".opus")) return "audio/opus";
-        if (path.endsWith(".wav")) return "audio/wav";
-        if (path.endsWith(".m4a")) return "audio/mp4";
-        if (path.endsWith(".ogg")) return "audio/ogg";
-        if (path.endsWith(".webm")) return "audio/webm";
-        // Default to mpeg for unknown types (as most Plaud recordings are MP3)
-        return "audio/mpeg";
-    };
-
-    const contentType = getContentType(recording.storagePath);
+    const contentType = getAudioMimeType(recording.storagePath);
     const fileSize = audioBuffer.length;
+    const wantsDownload = isAudioDownloadRequest(request);
 
-    // Parse Range header for seeking support
-    const rangeHeader = request.headers.get("range");
+    const downloadHeaders: Record<string, string> = wantsDownload
+        ? {
+              "Content-Disposition": contentDispositionAttachment(
+                  buildDownloadFilename(
+                      decryptText(recording.filename),
+                      recording.storagePath,
+                      recording.id,
+                  ),
+              ),
+              "Cache-Control": "private, no-store",
+          }
+        : {
+              "Cache-Control": "public, max-age=31536000, immutable",
+          };
+
+    // Attachment downloads always return the full file so the saved
+    // copy is complete. Range is still honored for in-app playback.
+    const rangeHeader = wantsDownload ? null : request.headers.get("range");
 
     if (rangeHeader) {
-        // Parse range header (e.g., "bytes=0-1023" or "bytes=1024-")
         const rangeMatch = rangeHeader.match(/bytes=(\d+)-(\d*)/);
 
         if (rangeMatch) {
@@ -67,9 +74,6 @@ export const GET = apiHandler<IdContext>(async (request, context) => {
                 ? Number.parseInt(rangeMatch[2], 10)
                 : fileSize - 1;
 
-            // Validate range values. We return raw 416 (without our error
-            // envelope) because `Content-Range: bytes */N` is the contract
-            // browsers parse, and they don't read JSON on a 416.
             if (
                 start < 0 ||
                 start >= fileSize ||
@@ -86,11 +90,8 @@ export const GET = apiHandler<IdContext>(async (request, context) => {
             }
 
             const chunkSize = end - start + 1;
-
-            // Extract the requested chunk
             const chunk = audioBuffer.slice(start, end + 1);
 
-            // Return 206 Partial Content
             return new NextResponse(new Uint8Array(chunk), {
                 status: 206,
                 headers: {
@@ -98,19 +99,18 @@ export const GET = apiHandler<IdContext>(async (request, context) => {
                     "Content-Length": chunkSize.toString(),
                     "Content-Range": `bytes ${start}-${end}/${fileSize}`,
                     "Accept-Ranges": "bytes",
-                    "Cache-Control": "public, max-age=31536000, immutable",
+                    ...downloadHeaders,
                 },
             });
         }
     }
 
-    // No range requested - return full file
     return new NextResponse(new Uint8Array(audioBuffer), {
         headers: {
             "Content-Type": contentType,
             "Content-Length": fileSize.toString(),
             "Accept-Ranges": "bytes",
-            "Cache-Control": "public, max-age=31536000, immutable",
+            ...downloadHeaders,
         },
     });
 });

--- a/src/app/api/recordings/[id]/route.ts
+++ b/src/app/api/recordings/[id]/route.ts
@@ -8,8 +8,12 @@ import {
     webhookDeliveries,
 } from "@/db/schema";
 import { requireApiSession } from "@/lib/auth-server";
-import { decryptText } from "@/lib/encryption/fields";
+import { decryptText, encryptText } from "@/lib/encryption/fields";
 import { AppError, apiHandler, ErrorCode } from "@/lib/errors";
+import {
+    MAX_RECORDING_TITLE_LENGTH,
+    normalizeRecordingTitle,
+} from "@/lib/recordings/filename";
 import { createUserStorageProvider } from "@/lib/storage/factory";
 import { emitEvent } from "@/lib/webhooks/emit";
 import { createRedactedWebhookPayload } from "@/lib/webhooks/payload";
@@ -67,6 +71,74 @@ export const GET = apiHandler<IdContext>(async (request, context) => {
         transcription: transcription
             ? { ...transcription, text: decryptText(transcription.text) }
             : null,
+    });
+});
+
+export const PATCH = apiHandler<IdContext>(async (request, context) => {
+    const session = await requireApiSession(request);
+    const { id } = await (context as IdContext).params;
+    const body = (await request.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+    >;
+
+    if (typeof body.filename !== "string") {
+        throw new AppError(
+            ErrorCode.INVALID_INPUT,
+            "filename must be a string",
+            400,
+            { field: "filename" },
+        );
+    }
+
+    const filename = normalizeRecordingTitle(body.filename);
+    if (!filename) {
+        throw new AppError(
+            ErrorCode.INVALID_INPUT,
+            "Name cannot be empty",
+            400,
+            { field: "filename" },
+        );
+    }
+    if (filename.length > MAX_RECORDING_TITLE_LENGTH) {
+        throw new AppError(
+            ErrorCode.INVALID_INPUT,
+            `Name must be ${MAX_RECORDING_TITLE_LENGTH} characters or fewer`,
+            400,
+            { field: "filename", maxLength: MAX_RECORDING_TITLE_LENGTH },
+        );
+    }
+
+    const [updated] = await db
+        .update(recordings)
+        .set({
+            filename: encryptText(filename),
+            updatedAt: new Date(),
+        })
+        .where(
+            and(
+                eq(recordings.id, id),
+                eq(recordings.userId, session.user.id),
+                isNull(recordings.deletedAt),
+            ),
+        )
+        .returning({
+            id: recordings.id,
+            filename: recordings.filename,
+        });
+
+    if (!updated) {
+        throw new AppError(
+            ErrorCode.RECORDING_NOT_FOUND,
+            "Recording not found",
+            404,
+        );
+    }
+
+    await emitEvent("recording.updated", session.user.id, updated.id);
+
+    return NextResponse.json({
+        filename: decryptText(updated.filename),
     });
 });
 

--- a/src/app/api/recordings/[id]/route.ts
+++ b/src/app/api/recordings/[id]/route.ts
@@ -77,12 +77,13 @@ export const GET = apiHandler<IdContext>(async (request, context) => {
 export const PATCH = apiHandler<IdContext>(async (request, context) => {
     const session = await requireApiSession(request);
     const { id } = await (context as IdContext).params;
-    const body = (await request.json().catch(() => ({}))) as Record<
-        string,
-        unknown
-    >;
-
-    if (typeof body.filename !== "string") {
+    const body = (await request.json().catch(() => ({}))) as unknown;
+    if (
+        body === null ||
+        typeof body !== "object" ||
+        Array.isArray(body) ||
+        typeof (body as { filename?: unknown }).filename !== "string"
+    ) {
         throw new AppError(
             ErrorCode.INVALID_INPUT,
             "filename must be a string",
@@ -91,7 +92,9 @@ export const PATCH = apiHandler<IdContext>(async (request, context) => {
         );
     }
 
-    const filename = normalizeRecordingTitle(body.filename);
+    const filename = normalizeRecordingTitle(
+        (body as { filename: string }).filename,
+    );
     if (!filename) {
         throw new AppError(
             ErrorCode.INVALID_INPUT,

--- a/src/components/dashboard/recording-player-header.tsx
+++ b/src/components/dashboard/recording-player-header.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { AudioWaveform, Loader2 } from "lucide-react";
-import { CardHeader, CardTitle } from "@/components/ui/card";
+import { DownloadAudioButton } from "@/components/recordings/download-audio-button";
+import { RecordingTitle } from "@/components/recordings/recording-title";
+import { CardAction, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatBytes } from "@/lib/format-bytes";
 import { formatDateTime } from "@/lib/format-date";
 import { formatDuration } from "@/lib/format-duration";
@@ -14,6 +16,7 @@ interface Props {
     scrubberStyle: "waveform" | "slider";
     waveformStatus: "idle" | "ready" | "decoding" | "skipped" | "error";
     onDecodeWaveform: () => void;
+    onRenamed?: (filename: string) => void;
 }
 
 /**
@@ -32,6 +35,7 @@ export function RecordingPlayerHeader({
     scrubberStyle,
     waveformStatus,
     onDecodeWaveform,
+    onRenamed,
 }: Props) {
     const metaParts: string[] = [
         formatDateTime(recording.startTime, "relative"),
@@ -41,9 +45,17 @@ export function RecordingPlayerHeader({
 
     return (
         <CardHeader className="gap-1">
-            <CardTitle className="truncate text-lg">
-                {recording.filename}
+            <CardTitle className="min-w-0 text-lg">
+                <RecordingTitle
+                    recordingId={recording.id}
+                    filename={recording.filename}
+                    onRenamed={onRenamed}
+                    className="text-lg"
+                />
             </CardTitle>
+            <CardAction>
+                <DownloadAudioButton recordingId={recording.id} />
+            </CardAction>
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
                 {metaParts.map((part, i) => (
                     <span key={part} className="inline-flex items-center gap-2">

--- a/src/components/dashboard/recording-player.tsx
+++ b/src/components/dashboard/recording-player.tsx
@@ -11,6 +11,7 @@ import type { Recording } from "@/types/recording";
 interface RecordingPlayerProps {
     recording: Recording;
     onEnded?: () => void;
+    onRenamed?: (filename: string) => void;
     initialPlaybackSpeed?: number;
     initialVolume?: number;
     initialAutoPlayNext?: boolean;
@@ -33,6 +34,7 @@ interface RecordingPlayerProps {
 export function RecordingPlayer({
     recording,
     onEnded,
+    onRenamed,
     initialPlaybackSpeed = 1.0,
     initialVolume = 75,
     initialAutoPlayNext = false,
@@ -93,6 +95,7 @@ export function RecordingPlayer({
                 scrubberStyle={scrubberStyle}
                 waveformStatus={waveformStatus}
                 onDecodeWaveform={triggerWaveformDecode}
+                onRenamed={onRenamed}
             />
             <CardContent>
                 <RecordingPlayerControls

--- a/src/components/dashboard/recording-row.tsx
+++ b/src/components/dashboard/recording-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Loader2, MoreHorizontal, Play, Trash2 } from "lucide-react";
+import { Download, Loader2, MoreHorizontal, Play, Trash2 } from "lucide-react";
 import { useConfirm } from "@/components/confirm-dialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { formatDateTime } from "@/lib/format-date";
 import { formatDurationMs } from "@/lib/format-duration";
+import { recordingAudioDownloadPath } from "@/lib/recordings/filename";
 import { cn } from "@/lib/utils";
 import type { DateTimeFormat } from "@/types/common";
 import type { Recording } from "@/types/recording";
@@ -119,6 +120,16 @@ export function RecordingRow({
                         <DropdownMenuItem onSelect={() => onSelect(recording)}>
                             <Play />
                             Open
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                            onSelect={() => {
+                                window.location.assign(
+                                    recordingAudioDownloadPath(recording.id),
+                                );
+                            }}
+                        >
+                            <Download />
+                            Download audio
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
                         <DropdownMenuItem

--- a/src/components/dashboard/workstation-detail-pane.tsx
+++ b/src/components/dashboard/workstation-detail-pane.tsx
@@ -22,6 +22,7 @@ interface Props {
     /** Called after a browser-side transcription completes (refresh data). */
     onTranscribeComplete?: () => void;
     onSelectRecording: (r: Recording) => void;
+    onRenamed?: (filename: string) => void;
     onBackToList: () => void;
     /** When true, the pane is hidden (mobile list view active). */
     hiddenOnMobile: boolean;
@@ -49,6 +50,7 @@ export function WorkstationDetailPane({
     onTranscribe,
     onTranscribeComplete,
     onSelectRecording,
+    onRenamed,
     onBackToList,
     hiddenOnMobile,
     initialPlaybackSpeed,
@@ -86,6 +88,7 @@ export function WorkstationDetailPane({
                         initialVolume={initialVolume}
                         initialAutoPlayNext={initialAutoPlayNext}
                         scrubberStyle={scrubberStyle}
+                        onRenamed={onRenamed}
                         onEnded={() => {
                             const currentIndex = visibleRecordings.findIndex(
                                 (r) => r.id === currentRecording.id,

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -122,6 +122,9 @@ export function Workstation({
     const [paletteOpen, setPaletteOpen] = useState(false);
     const [shortcutsOpen, setShortcutsOpen] = useState(false);
     const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
+    const [filenameOverrides, setFilenameOverrides] = useState<
+        Map<string, string>
+    >(() => new Map());
     // On <lg viewports the list and detail panes can't coexist -- we
     // toggle between them instead of stacking. Desktop ignores this
     // state entirely (both panes render via the grid).
@@ -133,13 +136,24 @@ export function Workstation({
 
     // Filter out optimistically-hidden (deleted) rows.
     const visibleRecordings = useMemo(
-        () => recordings.filter((r) => !hiddenIds.has(r.id)),
-        [recordings, hiddenIds],
+        () =>
+            recordings
+                .filter((r) => !hiddenIds.has(r.id))
+                .map((r) => {
+                    const filename = filenameOverrides.get(r.id);
+                    return filename !== undefined ? { ...r, filename } : r;
+                }),
+        [recordings, hiddenIds, filenameOverrides],
     );
 
     const currentTranscription = currentRecording
         ? transcriptions.get(currentRecording.id)
         : undefined;
+
+    const selectedRecording = currentRecording
+        ? (visibleRecordings.find((r) => r.id === currentRecording.id) ??
+          currentRecording)
+        : null;
 
     // Keep currentRecording in sync with the recordings prop (updated
     // after refresh()). If the previously-selected recording is no
@@ -314,6 +328,16 @@ export function Workstation({
         [currentRecording, visibleRecordings, refresh],
     );
 
+    const handleRenamed = useCallback(
+        (filename: string) => {
+            const id = currentRecording?.id;
+            if (!id) return;
+            setFilenameOverrides((prev) => new Map(prev).set(id, filename));
+            refresh();
+        },
+        [currentRecording?.id, refresh],
+    );
+
     // Keyboard shortcuts (global). Disabled while any modal is open
     // so the modal owns keyboard focus exclusively. The shortcuts
     // dialog itself uses these very keys to navigate its rows.
@@ -411,13 +435,14 @@ export function Workstation({
                             </div>
 
                             <WorkstationDetailPane
-                                currentRecording={currentRecording}
+                                currentRecording={selectedRecording}
                                 currentTranscription={currentTranscription}
                                 isCurrentTranscribing={isCurrentTranscribing}
                                 visibleRecordings={visibleRecordings}
                                 onTranscribe={handleTranscribe}
                                 onTranscribeComplete={refresh}
                                 onSelectRecording={setCurrentRecording}
+                                onRenamed={handleRenamed}
                                 onBackToList={() => setMobileView("list")}
                                 hiddenOnMobile={mobileView === "list"}
                                 initialPlaybackSpeed={

--- a/src/components/dashboard/workstation.tsx
+++ b/src/components/dashboard/workstation.tsx
@@ -27,6 +27,10 @@ import {
     showNewRecordingNotification,
     showSyncCompleteNotification,
 } from "@/lib/notifications/browser";
+import {
+    applyFilenameOverrides,
+    reconcileFilenameOverrides,
+} from "@/lib/recordings/filename-overrides";
 import type { InitialSettings } from "@/lib/settings/initial-settings";
 import { SYNC_CONFIG } from "@/lib/sync-config";
 import { cn } from "@/lib/utils";
@@ -137,12 +141,10 @@ export function Workstation({
     // Filter out optimistically-hidden (deleted) rows.
     const visibleRecordings = useMemo(
         () =>
-            recordings
-                .filter((r) => !hiddenIds.has(r.id))
-                .map((r) => {
-                    const filename = filenameOverrides.get(r.id);
-                    return filename !== undefined ? { ...r, filename } : r;
-                }),
+            applyFilenameOverrides(
+                recordings.filter((r) => !hiddenIds.has(r.id)),
+                filenameOverrides,
+            ),
         [recordings, hiddenIds, filenameOverrides],
     );
 
@@ -175,6 +177,9 @@ export function Workstation({
             }
             return next.size === prev.size ? prev : next;
         });
+        setFilenameOverrides((prev) =>
+            reconcileFilenameOverrides(recordings, prev),
+        );
     }, [recordings]);
 
     const {

--- a/src/components/recordings/download-audio-button.tsx
+++ b/src/components/recordings/download-audio-button.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Download } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { recordingAudioDownloadPath } from "@/lib/recordings/filename";
+
+export function DownloadAudioButton({ recordingId }: { recordingId: string }) {
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Button asChild variant="ghost" size="icon-sm">
+                    <a
+                        href={recordingAudioDownloadPath(recordingId)}
+                        download
+                        rel="nofollow noreferrer"
+                        aria-label="Download original audio"
+                    >
+                        <Download className="size-4" />
+                    </a>
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+                Download original audio
+            </TooltipContent>
+        </Tooltip>
+    );
+}

--- a/src/components/recordings/recording-title.tsx
+++ b/src/components/recordings/recording-title.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Pencil } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/api-errors";
+import {
+    MAX_RECORDING_TITLE_LENGTH,
+    normalizeRecordingTitle,
+} from "@/lib/recordings/filename";
+import { cn } from "@/lib/utils";
+
+export function RecordingTitle({
+    recordingId,
+    filename,
+    onRenamed,
+    className,
+}: {
+    recordingId: string;
+    filename: string;
+    onRenamed?: (filename: string) => void;
+    className?: string;
+}) {
+    const [editing, setEditing] = useState(false);
+    const [draft, setDraft] = useState(filename);
+    const [saving, setSaving] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (!editing) setDraft(filename);
+    }, [filename, editing]);
+
+    useEffect(() => {
+        if (!editing) return;
+        const input = inputRef.current;
+        if (!input) return;
+        input.focus();
+        input.select();
+    }, [editing]);
+
+    const commit = async () => {
+        const next = normalizeRecordingTitle(draft);
+        if (!next) {
+            toast.error("Name cannot be empty");
+            setDraft(filename);
+            setEditing(false);
+            return;
+        }
+        if (next.length > MAX_RECORDING_TITLE_LENGTH) {
+            toast.error(
+                `Name must be ${MAX_RECORDING_TITLE_LENGTH} characters or fewer`,
+            );
+            return;
+        }
+        if (next === filename) {
+            setDraft(filename);
+            setEditing(false);
+            return;
+        }
+
+        setSaving(true);
+        try {
+            const response = await fetch(`/api/recordings/${recordingId}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ filename: next }),
+            });
+            if (!response.ok) {
+                toast.error(
+                    await getApiErrorMessage(response, "Failed to rename"),
+                );
+                return;
+            }
+            const body = (await response.json()) as { filename?: string };
+            const saved = body.filename ?? next;
+            setEditing(false);
+            setDraft(saved);
+            onRenamed?.(saved);
+        } catch {
+            toast.error("Failed to rename");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    if (editing) {
+        return (
+            <input
+                ref={inputRef}
+                value={draft}
+                disabled={saving}
+                maxLength={MAX_RECORDING_TITLE_LENGTH}
+                aria-label="Recording name"
+                onChange={(e) => setDraft(e.target.value)}
+                onBlur={() => {
+                    if (!saving) void commit();
+                }}
+                onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                        e.preventDefault();
+                        void commit();
+                    } else if (e.key === "Escape") {
+                        e.preventDefault();
+                        setDraft(filename);
+                        setEditing(false);
+                    }
+                }}
+                className={cn(
+                    "w-full min-w-0 rounded-md bg-transparent px-1 -mx-1 font-semibold outline-none",
+                    "focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+                    "disabled:opacity-60",
+                    className,
+                )}
+            />
+        );
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={() => setEditing(true)}
+            title="Rename"
+            aria-label={`Rename ${filename}`}
+            className={cn(
+                "group/title inline-flex max-w-full min-w-0 items-center gap-1.5 rounded-md text-left",
+                "hover:bg-accent/60 focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
+                "px-1 -mx-1 py-0.5",
+            )}
+        >
+            <span className={cn("truncate", className)}>{filename}</span>
+            <Pencil
+                className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/title:opacity-100 group-focus-visible/title:opacity-100"
+                aria-hidden="true"
+            />
+        </button>
+    );
+}

--- a/src/components/recordings/recording-title.tsx
+++ b/src/components/recordings/recording-title.tsx
@@ -97,6 +97,7 @@ export function RecordingTitle({
                 }}
                 onKeyDown={(e) => {
                     if (e.key === "Enter") {
+                        if (e.nativeEvent.isComposing) return;
                         e.preventDefault();
                         void commit();
                     } else if (e.key === "Escape") {

--- a/src/components/recordings/recording-workstation.tsx
+++ b/src/components/recordings/recording-workstation.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeft, Loader2, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { RecordingPlayer } from "@/components/dashboard/recording-player";
 import {
@@ -67,7 +67,13 @@ export function RecordingWorkstation({
         setFilename(recording.filename);
     }, [recording.filename]);
 
-    const displayRecording = { ...recording, filename };
+    const displayRecording = useMemo(
+        () =>
+            filename === recording.filename
+                ? recording
+                : { ...recording, filename },
+        [recording, filename],
+    );
 
     const handleRenamed = useCallback(
         (next: string) => {

--- a/src/components/recordings/recording-workstation.tsx
+++ b/src/components/recordings/recording-workstation.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeft, Loader2, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { RecordingPlayer } from "@/components/dashboard/recording-player";
 import {
@@ -10,6 +10,8 @@ import {
     type TranscriptOption,
 } from "@/components/dashboard/transcription-panel";
 import { LocalTime } from "@/components/local-time";
+import { DownloadAudioButton } from "@/components/recordings/download-audio-button";
+import { RecordingTitle } from "@/components/recordings/recording-title";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -59,6 +61,21 @@ export function RecordingWorkstation({
     const [isTranscribing, setIsTranscribing] = useState(false);
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
+    const [filename, setFilename] = useState(recording.filename);
+
+    useEffect(() => {
+        setFilename(recording.filename);
+    }, [recording.filename]);
+
+    const displayRecording = { ...recording, filename };
+
+    const handleRenamed = useCallback(
+        (next: string) => {
+            setFilename(next);
+            refresh();
+        },
+        [refresh],
+    );
 
     const handleTranscribe = useCallback(async () => {
         setIsTranscribing(true);
@@ -120,13 +137,19 @@ export function RecordingWorkstation({
                         <ArrowLeft className="size-4" />
                     </Button>
                     <div className="flex-1 min-w-0">
-                        <h1 className="text-3xl font-semibold truncate">
-                            {recording.filename}
+                        <h1 className="min-w-0">
+                            <RecordingTitle
+                                recordingId={recording.id}
+                                filename={filename}
+                                onRenamed={handleRenamed}
+                                className="text-3xl font-semibold"
+                            />
                         </h1>
                         <p className="text-muted-foreground text-sm mt-1">
                             <LocalTime value={recording.startTime} />
                         </p>
                     </div>
+                    <DownloadAudioButton recordingId={recording.id} />
                     <Button
                         onClick={() => setDeleteDialogOpen(true)}
                         variant="outline"
@@ -141,14 +164,15 @@ export function RecordingWorkstation({
                 {/* Content */}
                 <div className="space-y-6">
                     <RecordingPlayer
-                        recording={recording}
+                        recording={displayRecording}
                         initialPlaybackSpeed={initialPlaybackSpeed}
                         initialVolume={initialVolume}
                         initialAutoPlayNext={initialAutoPlayNext}
                         scrubberStyle={scrubberStyle}
+                        onRenamed={handleRenamed}
                     />
                     <TranscriptionPanel
-                        recording={recording}
+                        recording={displayRecording}
                         transcription={transcription}
                         transcripts={transcripts}
                         isTranscribing={isTranscribing}

--- a/src/hooks/use-playback-engine.ts
+++ b/src/hooks/use-playback-engine.ts
@@ -51,10 +51,7 @@ export function usePlaybackEngine({
     const isSeekingRef = useRef(false);
 
     // Reset transport state and re-point src whenever the recording
-    // changes. The src swap is duplicated in the listener-wiring
-    // effect below for the case where the element wasn't mounted yet
-    // when this effect ran -- both branches guard with the `audio.src
-    // !==` check so the swap is idempotent.
+    // *id* changes. Filename edits must not remount playback.
     useEffect(() => {
         setCurrentTime(0);
         setDuration(0);
@@ -64,7 +61,7 @@ export function usePlaybackEngine({
             audioRef.current.src = `/api/recordings/${recording.id}/audio`;
             audioRef.current.load();
         }
-    }, [recording]);
+    }, [recording.id]);
 
     useEffect(() => {
         if (audioRef.current) {
@@ -130,7 +127,7 @@ export function usePlaybackEngine({
             audio.removeEventListener("ended", handleEnded);
             audio.removeEventListener("seeked", handleSeeked);
         };
-    }, [recording, autoPlayNext, onEnded]);
+    }, [recording.id, autoPlayNext, onEnded]);
 
     const togglePlayPause = useCallback(() => {
         if (!audioRef.current) return;

--- a/src/lib/recordings/filename-overrides.ts
+++ b/src/lib/recordings/filename-overrides.ts
@@ -1,0 +1,28 @@
+/**
+ * Optimistic filename overlays for the dashboard list. Applied only
+ * until a refreshed `recordings` snapshot arrives; after that, server
+ * truth wins (sync, another client, or our own PATCH).
+ */
+
+export function applyFilenameOverrides<
+    T extends { id: string; filename: string },
+>(recordings: T[], overrides: Map<string, string>): T[] {
+    if (overrides.size === 0) return recordings;
+    return recordings.map((recording) => {
+        const filename = overrides.get(recording.id);
+        return filename !== undefined ? { ...recording, filename } : recording;
+    });
+}
+
+/**
+ * End the pending overlay window. Workstation always receives the full
+ * list: ids in the snapshot have server truth, ids missing from it are
+ * gone. Either way the overlay is done.
+ */
+export function reconcileFilenameOverrides(
+    _recordings: readonly { id: string }[],
+    overrides: Map<string, string>,
+): Map<string, string> {
+    if (overrides.size === 0) return overrides;
+    return new Map();
+}

--- a/src/lib/recordings/filename.ts
+++ b/src/lib/recordings/filename.ts
@@ -1,0 +1,82 @@
+/** Max stored/display title length. Download basenames use the same cap. */
+export const MAX_RECORDING_TITLE_LENGTH = 200;
+
+const DOWNLOAD_PARAM_TRUE = new Set(["1", "true", "yes"]);
+
+function stripControlChars(value: string): string {
+    let out = "";
+    for (const char of value) {
+        const code = char.charCodeAt(0);
+        if (code < 32 || code === 127) continue;
+        out += char;
+    }
+    return out;
+}
+
+/**
+ * Strip C0 controls and trim. Empty string means the caller should reject.
+ */
+export function normalizeRecordingTitle(value: string): string {
+    return stripControlChars(value).trim();
+}
+
+export function audioExtension(storagePath: string): string {
+    const match = storagePath.match(/\.([a-z0-9]+)$/i);
+    return match ? match[1].toLowerCase() : "mp3";
+}
+
+export function recordingAudioDownloadPath(recordingId: string): string {
+    return `/api/recordings/${recordingId}/audio?download=1`;
+}
+
+export function isAudioDownloadRequest(request: Request): boolean {
+    const value = new URL(request.url).searchParams.get("download");
+    if (value === null) return false;
+    return DOWNLOAD_PARAM_TRUE.has(value.toLowerCase());
+}
+
+export function sanitizeDownloadBasename(title: string): string {
+    const cleaned = stripControlChars(title)
+        .replace(/[/\\:*?"<>|]/g, "-")
+        .replace(/\s+/g, " ")
+        .trim();
+    if (!cleaned) return "";
+    return cleaned.length > MAX_RECORDING_TITLE_LENGTH
+        ? cleaned.slice(0, MAX_RECORDING_TITLE_LENGTH).trim()
+        : cleaned;
+}
+
+/**
+ * Filesystem-safe download name from the recording title, with the
+ * extension taken from `storagePath` (mp3/wav/m4a/…). Falls back to
+ * `fallbackId` when the title sanitizes to empty.
+ */
+export function buildDownloadFilename(
+    title: string,
+    storagePath: string,
+    fallbackId: string,
+): string {
+    const ext = audioExtension(storagePath);
+    const extSuffix = `.${ext}`;
+    let base =
+        sanitizeDownloadBasename(title) ||
+        sanitizeDownloadBasename(fallbackId) ||
+        "recording";
+    if (base.toLowerCase().endsWith(extSuffix)) {
+        base = base.slice(0, -extSuffix.length);
+    }
+    return `${base}${extSuffix}`;
+}
+
+/**
+ * RFC 6266 / RFC 5987 Content-Disposition for an attachment download.
+ * `filename` is the ASCII fallback; `filename*` carries the UTF-8 name.
+ */
+export function contentDispositionAttachment(filename: string): string {
+    const ascii = filename.replace(/[^\x20-\x7E]/g, "_").replace(/["\\]/g, "_");
+    const encoded = encodeURIComponent(filename).replace(
+        /['()*]/g,
+        (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+    );
+    return `attachment; filename="${ascii}"; filename*=UTF-8''${encoded}`;
+}

--- a/src/lib/recordings/filename.ts
+++ b/src/lib/recordings/filename.ts
@@ -13,6 +13,14 @@ function stripControlChars(value: string): string {
     return out;
 }
 
+/** CON, PRN, AUX, NUL, COM1–9, LPT1–9 — reserved even with an extension. */
+const WINDOWS_RESERVED_BASENAME =
+    /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\.[^.]+)?$/i;
+
+function escapeWindowsReservedBasename(name: string): string {
+    return WINDOWS_RESERVED_BASENAME.test(name) ? `_${name}` : name;
+}
+
 /**
  * Strip C0 controls and trim. Empty string means the caller should reject.
  */
@@ -41,9 +49,11 @@ export function sanitizeDownloadBasename(title: string): string {
         .replace(/\s+/g, " ")
         .trim();
     if (!cleaned) return "";
-    return cleaned.length > MAX_RECORDING_TITLE_LENGTH
-        ? cleaned.slice(0, MAX_RECORDING_TITLE_LENGTH).trim()
-        : cleaned;
+    const truncated =
+        cleaned.length > MAX_RECORDING_TITLE_LENGTH
+            ? cleaned.slice(0, MAX_RECORDING_TITLE_LENGTH).trim()
+            : cleaned;
+    return escapeWindowsReservedBasename(truncated);
 }
 
 /**
@@ -65,6 +75,7 @@ export function buildDownloadFilename(
     if (base.toLowerCase().endsWith(extSuffix)) {
         base = base.slice(0, -extSuffix.length);
     }
+    base = escapeWindowsReservedBasename(base);
     return `${base}${extSuffix}`;
 }
 

--- a/src/tests/recordings/filename-overrides.test.ts
+++ b/src/tests/recordings/filename-overrides.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+    applyFilenameOverrides,
+    reconcileFilenameOverrides,
+} from "@/lib/recordings/filename-overrides";
+
+describe("filename overlays", () => {
+    it("applies a pending overlay and yields to a refreshed server snapshot", () => {
+        const recordings = [
+            { id: "rec-1", filename: "Planning Call.m4a" },
+            { id: "rec-2", filename: "Standup.m4a" },
+        ];
+        const overrides = new Map([["rec-1", "local-inline-rename.m4a"]]);
+
+        expect(applyFilenameOverrides(recordings, overrides)[0].filename).toBe(
+            "local-inline-rename.m4a",
+        );
+
+        const refreshed = [
+            { id: "rec-1", filename: "plaud-other-client-name.m4a" },
+            { id: "rec-2", filename: "Standup.m4a" },
+        ];
+        const reconciled = reconcileFilenameOverrides(refreshed, overrides);
+        expect(reconciled.size).toBe(0);
+        expect(applyFilenameOverrides(refreshed, reconciled)[0].filename).toBe(
+            "plaud-other-client-name.m4a",
+        );
+    });
+
+    it("drops the overlay even when the snapshot filename matches the local rename", () => {
+        const overrides = new Map([["rec-1", "Q4 planning"]]);
+        const snapshot = [{ id: "rec-1", filename: "Q4 planning" }];
+        expect(reconcileFilenameOverrides(snapshot, overrides).size).toBe(0);
+    });
+
+    it("keeps the overlay Map identity when there is nothing to drop", () => {
+        const empty = new Map<string, string>();
+        expect(reconcileFilenameOverrides([{ id: "rec-1" }], empty)).toBe(
+            empty,
+        );
+    });
+
+    it("returns the original recordings array when no overlays exist", () => {
+        const recordings = [{ id: "rec-1", filename: "A" }];
+        expect(applyFilenameOverrides(recordings, new Map())).toBe(recordings);
+    });
+});

--- a/src/tests/recordings/filename.test.ts
+++ b/src/tests/recordings/filename.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+    audioExtension,
+    buildDownloadFilename,
+    contentDispositionAttachment,
+    isAudioDownloadRequest,
+    MAX_RECORDING_TITLE_LENGTH,
+    normalizeRecordingTitle,
+    recordingAudioDownloadPath,
+    sanitizeDownloadBasename,
+} from "@/lib/recordings/filename";
+
+describe("normalizeRecordingTitle", () => {
+    it("trims and strips control characters", () => {
+        expect(normalizeRecordingTitle("  Q4 planning\u0000  ")).toBe(
+            "Q4 planning",
+        );
+        expect(normalizeRecordingTitle("\n\t")).toBe("");
+    });
+});
+
+describe("audioExtension", () => {
+    it("reads the trailing extension, defaulting to mp3", () => {
+        expect(audioExtension("user-1/rec.wav")).toBe("wav");
+        expect(audioExtension("user-1/rec.M4A")).toBe("m4a");
+        expect(audioExtension("user-1/rec")).toBe("mp3");
+    });
+});
+
+describe("sanitizeDownloadBasename", () => {
+    it("replaces filesystem-illegal characters", () => {
+        expect(sanitizeDownloadBasename('foo/bar:baz*"<>|')).toBe(
+            "foo-bar-baz-----",
+        );
+    });
+
+    it("collapses illegal characters and returns empty for whitespace", () => {
+        expect(sanitizeDownloadBasename("///")).toBe("---");
+        expect(sanitizeDownloadBasename("   ")).toBe("");
+    });
+
+    it("truncates to the shared title cap", () => {
+        const long = "a".repeat(MAX_RECORDING_TITLE_LENGTH + 40);
+        expect(sanitizeDownloadBasename(long).length).toBe(
+            MAX_RECORDING_TITLE_LENGTH,
+        );
+    });
+});
+
+describe("buildDownloadFilename", () => {
+    it("appends the storage extension and falls back to the recording id", () => {
+        expect(
+            buildDownloadFilename("Planning Call", "u/rec.mp3", "rec-1"),
+        ).toBe("Planning Call.mp3");
+        expect(buildDownloadFilename("   ", "u/rec.wav", "rec-1")).toBe(
+            "rec-1.wav",
+        );
+    });
+
+    it("does not double the extension when the title already has it", () => {
+        expect(buildDownloadFilename("memo.m4a", "u/file.m4a", "id")).toBe(
+            "memo.m4a",
+        );
+        expect(buildDownloadFilename("memo.MP3", "u/file.mp3", "id")).toBe(
+            "memo.mp3",
+        );
+    });
+
+    it("keeps unicode in the download name", () => {
+        expect(buildDownloadFilename("会議 日本語", "u/a.mp3", "id")).toBe(
+            "会議 日本語.mp3",
+        );
+    });
+});
+
+describe("contentDispositionAttachment", () => {
+    it("emits ASCII filename plus RFC 5987 filename*", () => {
+        const header = contentDispositionAttachment("会議.mp3");
+        expect(header).toContain('filename="__.mp3"');
+        expect(header).toContain("filename*=UTF-8''");
+        expect(header).toContain(encodeURIComponent("会議.mp3"));
+    });
+
+    it("escapes quotes in the ASCII fallback", () => {
+        const header = contentDispositionAttachment('say "hi".mp3');
+        expect(header).toContain('filename="say _hi_.mp3"');
+    });
+});
+
+describe("isAudioDownloadRequest / recordingAudioDownloadPath", () => {
+    it("treats download=1/true/yes as a download", () => {
+        expect(
+            isAudioDownloadRequest(
+                new Request(
+                    "http://localhost/api/recordings/x/audio?download=1",
+                ),
+            ),
+        ).toBe(true);
+        expect(
+            isAudioDownloadRequest(
+                new Request(
+                    "http://localhost/api/recordings/x/audio?download=true",
+                ),
+            ),
+        ).toBe(true);
+        expect(
+            isAudioDownloadRequest(
+                new Request("http://localhost/api/recordings/x/audio"),
+            ),
+        ).toBe(false);
+        expect(
+            isAudioDownloadRequest(
+                new Request(
+                    "http://localhost/api/recordings/x/audio?download=0",
+                ),
+            ),
+        ).toBe(false);
+    });
+
+    it("builds the session-cookie download path", () => {
+        expect(recordingAudioDownloadPath("rec-1")).toBe(
+            "/api/recordings/rec-1/audio?download=1",
+        );
+    });
+});

--- a/src/tests/recordings/filename.test.ts
+++ b/src/tests/recordings/filename.test.ts
@@ -45,6 +45,16 @@ describe("sanitizeDownloadBasename", () => {
             MAX_RECORDING_TITLE_LENGTH,
         );
     });
+
+    it("prefixes Windows reserved device names, including with an extension", () => {
+        expect(sanitizeDownloadBasename("CON")).toBe("_CON");
+        expect(sanitizeDownloadBasename("lpt1")).toBe("_lpt1");
+        expect(sanitizeDownloadBasename("COM3.mp3")).toBe("_COM3.mp3");
+        expect(sanitizeDownloadBasename("nul")).toBe("_nul");
+        expect(sanitizeDownloadBasename("AUX")).toBe("_AUX");
+        expect(sanitizeDownloadBasename("PRN")).toBe("_PRN");
+        expect(sanitizeDownloadBasename("Meeting")).toBe("Meeting");
+    });
 });
 
 describe("buildDownloadFilename", () => {
@@ -69,6 +79,18 @@ describe("buildDownloadFilename", () => {
     it("keeps unicode in the download name", () => {
         expect(buildDownloadFilename("会議 日本語", "u/a.mp3", "id")).toBe(
             "会議 日本語.mp3",
+        );
+    });
+
+    it("prefixes reserved basenames after stripping a matching audio extension", () => {
+        expect(buildDownloadFilename("CON", "u/rec.mp3", "id")).toBe(
+            "_CON.mp3",
+        );
+        expect(buildDownloadFilename("CON.mp3", "u/rec.mp3", "id")).toBe(
+            "_CON.mp3",
+        );
+        expect(buildDownloadFilename("LPT1.wav", "u/rec.wav", "id")).toBe(
+            "_LPT1.wav",
         );
     });
 });

--- a/src/tests/regressions/217-rename-recording.test.ts
+++ b/src/tests/regressions/217-rename-recording.test.ts
@@ -52,6 +52,7 @@ vi.mock("@/lib/storage/factory", () => ({
 
 import { PATCH as patchRecording } from "@/app/api/recordings/[id]/route";
 import { db } from "@/db";
+import { recordings } from "@/db/schema";
 import { requireApiSession } from "@/lib/auth-server";
 import { encryptText } from "@/lib/encryption/fields";
 import { ErrorCode } from "@/lib/errors";
@@ -71,14 +72,48 @@ function patchRequest(body: unknown) {
 }
 
 function mockUpdateReturning(row: unknown) {
+    const whereSpy = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue(row ? [row] : []),
+    });
     const set = vi.fn((values: Record<string, unknown>) => ({
         values,
-        where: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue(row ? [row] : []),
-        }),
+        where: whereSpy,
     }));
     (db.update as Mock).mockReturnValue({ set });
-    return set;
+    return { set, whereSpy };
+}
+
+/**
+ * Walk a Drizzle SQL/expression tree looking for a reference to the
+ * given column object. Same approach as the #56 delete-route tests.
+ */
+function exprReferencesColumn(
+    expr: unknown,
+    col: unknown,
+    seen = new Set<unknown>(),
+): boolean {
+    if (expr == null || typeof expr !== "object") return false;
+    if (expr === col) return true;
+    if (seen.has(expr)) return false;
+    seen.add(expr);
+    for (const key of [
+        "queryChunks",
+        "sql",
+        "left",
+        "right",
+        "value",
+        "args",
+        "chunks",
+        "expr",
+    ]) {
+        const v = (expr as Record<string, unknown>)[key];
+        if (Array.isArray(v)) {
+            if (v.some((x) => exprReferencesColumn(x, col, seen))) return true;
+        } else if (exprReferencesColumn(v, col, seen)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 describe("PATCH /api/recordings/[id]", () => {
@@ -90,7 +125,7 @@ describe("PATCH /api/recordings/[id]", () => {
     });
 
     it("encrypts the new title at rest and returns plaintext", async () => {
-        const set = mockUpdateReturning({
+        const { set } = mockUpdateReturning({
             id: "rec-1",
             filename: "encrypted:Q4 planning",
         });
@@ -151,8 +186,20 @@ describe("PATCH /api/recordings/[id]", () => {
         expect(db.update).not.toHaveBeenCalled();
     });
 
+    it("rejects a JSON null body", async () => {
+        const response = await patchRecording(
+            patchRequest(null),
+            routeParams(),
+        );
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+            code: ErrorCode.INVALID_INPUT,
+        });
+        expect(db.update).not.toHaveBeenCalled();
+    });
+
     it("returns 404 when the row is missing or owned by another user", async () => {
-        mockUpdateReturning(null);
+        const { whereSpy } = mockUpdateReturning(null);
 
         const response = await patchRecording(
             patchRequest({ filename: "New name" }),
@@ -164,5 +211,13 @@ describe("PATCH /api/recordings/[id]", () => {
             code: ErrorCode.RECORDING_NOT_FOUND,
         });
         expect(emitEvent).not.toHaveBeenCalled();
+
+        const whereExpr = whereSpy.mock.calls.at(-1)?.[0];
+        expect(whereExpr).toBeDefined();
+        expect(exprReferencesColumn(whereExpr, recordings.userId)).toBe(true);
+        expect(exprReferencesColumn(whereExpr, recordings.id)).toBe(true);
+        expect(exprReferencesColumn(whereExpr, recordings.deletedAt)).toBe(
+            true,
+        );
     });
 });

--- a/src/tests/regressions/217-rename-recording.test.ts
+++ b/src/tests/regressions/217-rename-recording.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Regression tests for issue #217:
+ *   Inline renaming of recording titles via PATCH /api/recordings/[id]
+ *
+ * Covers:
+ *   1. Authenticated rename encrypts the title at rest and returns plaintext
+ *   2. Empty / missing / overlong names are 400
+ *   3. 404 for another user's recording / tombstoned row
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/lib/posthog-server", () => ({
+    captureServerException: vi.fn(),
+    captureServerEvent: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        update: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+    requireApiSession: vi.fn().mockResolvedValue({
+        user: { id: "user-1" },
+    }),
+}));
+
+vi.mock("@/lib/encryption/fields", () => ({
+    decryptText: vi.fn((value: string | null | undefined) =>
+        typeof value === "string" ? value.replace(/^encrypted:/, "") : value,
+    ),
+    encryptText: vi.fn((value: string) => `encrypted:${value}`),
+}));
+
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { PATCH as patchRecording } from "@/app/api/recordings/[id]/route";
+import { db } from "@/db";
+import { requireApiSession } from "@/lib/auth-server";
+import { encryptText } from "@/lib/encryption/fields";
+import { ErrorCode } from "@/lib/errors";
+import { MAX_RECORDING_TITLE_LENGTH } from "@/lib/recordings/filename";
+import { emitEvent } from "@/lib/webhooks/emit";
+
+function routeParams(id = "rec-1") {
+    return { params: Promise.resolve({ id }) };
+}
+
+function patchRequest(body: unknown) {
+    return new Request("http://localhost/api/recordings/rec-1", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+function mockUpdateReturning(row: unknown) {
+    const set = vi.fn((values: Record<string, unknown>) => ({
+        values,
+        where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue(row ? [row] : []),
+        }),
+    }));
+    (db.update as Mock).mockReturnValue({ set });
+    return set;
+}
+
+describe("PATCH /api/recordings/[id]", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (requireApiSession as unknown as Mock).mockResolvedValue({
+            user: { id: "user-1" },
+        });
+    });
+
+    it("encrypts the new title at rest and returns plaintext", async () => {
+        const set = mockUpdateReturning({
+            id: "rec-1",
+            filename: "encrypted:Q4 planning",
+        });
+
+        const response = await patchRecording(
+            patchRequest({ filename: "  Q4 planning  " }),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(200);
+        expect(encryptText).toHaveBeenCalledWith("Q4 planning");
+        expect(set).toHaveBeenCalledWith(
+            expect.objectContaining({ filename: "encrypted:Q4 planning" }),
+        );
+        await expect(response.json()).resolves.toEqual({
+            filename: "Q4 planning",
+        });
+        expect(emitEvent).toHaveBeenCalledWith(
+            "recording.updated",
+            "user-1",
+            "rec-1",
+        );
+    });
+
+    it("rejects a missing or non-string filename", async () => {
+        const response = await patchRecording(patchRequest({}), routeParams());
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+            code: ErrorCode.INVALID_INPUT,
+        });
+        expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects an empty name after trimming", async () => {
+        const response = await patchRecording(
+            patchRequest({ filename: "   " }),
+            routeParams(),
+        );
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+            code: ErrorCode.INVALID_INPUT,
+            error: "Name cannot be empty",
+        });
+        expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects an overlong name", async () => {
+        const response = await patchRecording(
+            patchRequest({
+                filename: "a".repeat(MAX_RECORDING_TITLE_LENGTH + 1),
+            }),
+            routeParams(),
+        );
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toMatchObject({
+            code: ErrorCode.INVALID_INPUT,
+        });
+        expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the row is missing or owned by another user", async () => {
+        mockUpdateReturning(null);
+
+        const response = await patchRecording(
+            patchRequest({ filename: "New name" }),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toMatchObject({
+            code: ErrorCode.RECORDING_NOT_FOUND,
+        });
+        expect(emitEvent).not.toHaveBeenCalled();
+    });
+});

--- a/src/tests/regressions/217-rename-recording.test.ts
+++ b/src/tests/regressions/217-rename-recording.test.ts
@@ -10,6 +10,14 @@
 
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
+vi.mock("@/lib/env", () => ({
+    env: {
+        DEFAULT_STORAGE_TYPE: "local",
+        ENCRYPTION_KEY:
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    },
+}));
+
 vi.mock("@/lib/posthog-server", () => ({
     captureServerException: vi.fn(),
     captureServerEvent: vi.fn(),
@@ -36,6 +44,10 @@ vi.mock("@/lib/encryption/fields", () => ({
 
 vi.mock("@/lib/webhooks/emit", () => ({
     emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/storage/factory", () => ({
+    createUserStorageProvider: vi.fn(),
 }));
 
 import { PATCH as patchRecording } from "@/app/api/recordings/[id]/route";

--- a/src/tests/regressions/229-audio-download.test.ts
+++ b/src/tests/regressions/229-audio-download.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression tests for issue #229:
+ *   Download the original audio file from the web app via
+ *   GET /api/recordings/[id]/audio?download=1
+ *
+ * Covers:
+ *   1. Authenticated download sets Content-Disposition (title + storage ext)
+ *   2. Playback (no download param) does not set Content-Disposition
+ *   3. Download ignores Range and returns the full file
+ *   4. 404 for another user's recording / missing row
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/lib/posthog-server", () => ({
+    captureServerException: vi.fn(),
+    captureServerEvent: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/auth-server", () => ({
+    requireApiSession: vi.fn().mockResolvedValue({
+        user: { id: "user-1" },
+    }),
+}));
+
+vi.mock("@/lib/encryption/fields", () => ({
+    decryptText: vi.fn((value: string | null | undefined) =>
+        typeof value === "string" ? value.replace(/^encrypted:/, "") : value,
+    ),
+}));
+
+vi.mock("@/lib/storage/factory", () => ({
+    createUserStorageProvider: vi.fn().mockResolvedValue({
+        downloadFile: vi.fn().mockResolvedValue(Buffer.from("audio-bytes")),
+    }),
+}));
+
+import { GET as getAudio } from "@/app/api/recordings/[id]/audio/route";
+import { db } from "@/db";
+import { requireApiSession } from "@/lib/auth-server";
+import { ErrorCode } from "@/lib/errors";
+import { createUserStorageProvider } from "@/lib/storage/factory";
+
+const now = new Date("2026-05-06T12:00:00.000Z");
+const audioBytes = Buffer.from("audio-bytes");
+
+function recordingRow(overrides: Record<string, unknown> = {}) {
+    return {
+        id: "rec-1",
+        userId: "user-1",
+        deviceSn: "SN-1",
+        plaudFileId: "plaud-1",
+        filename: "encrypted:Planning Call",
+        duration: 120000,
+        startTime: now,
+        endTime: now,
+        filesize: audioBytes.length,
+        fileMd5: "abc",
+        storageType: "local",
+        storagePath: "user-1/rec.mp3",
+        downloadedAt: now,
+        plaudVersion: "1",
+        timezone: null,
+        zonemins: null,
+        scene: null,
+        isTrash: false,
+        deletedAt: null,
+        createdAt: now,
+        updatedAt: now,
+        ...overrides,
+    };
+}
+
+function selectRecording(row: unknown) {
+    (db.select as Mock).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue(row ? [row] : []),
+            }),
+        }),
+    });
+}
+
+function routeParams(id = "rec-1") {
+    return { params: Promise.resolve({ id }) };
+}
+
+describe("GET /api/recordings/[id]/audio?download=1", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (requireApiSession as unknown as Mock).mockResolvedValue({
+            user: { id: "user-1" },
+        });
+        (createUserStorageProvider as Mock).mockResolvedValue({
+            downloadFile: vi.fn().mockResolvedValue(audioBytes),
+        });
+    });
+
+    it("returns the original file as an attachment named from the title", async () => {
+        selectRecording(recordingRow());
+
+        const response = await getAudio(
+            new Request(
+                "http://localhost/api/recordings/rec-1/audio?download=1",
+            ),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("Content-Type")).toBe("audio/mpeg");
+        expect(response.headers.get("Content-Disposition")).toContain(
+            "attachment",
+        );
+        expect(response.headers.get("Content-Disposition")).toContain(
+            "Planning Call.mp3",
+        );
+        expect(await response.text()).toBe("audio-bytes");
+    });
+
+    it("uses the storage-path extension for non-mp3 originals", async () => {
+        selectRecording(recordingRow({ storagePath: "user-1/interview.m4a" }));
+
+        const response = await getAudio(
+            new Request(
+                "http://localhost/api/recordings/rec-1/audio?download=1",
+            ),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("Content-Type")).toBe("audio/mp4");
+        expect(response.headers.get("Content-Disposition")).toContain(
+            "Planning Call.m4a",
+        );
+    });
+
+    it("does not set Content-Disposition for in-app playback", async () => {
+        selectRecording(recordingRow());
+
+        const response = await getAudio(
+            new Request("http://localhost/api/recordings/rec-1/audio"),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("Content-Disposition")).toBeNull();
+        expect(response.headers.get("Accept-Ranges")).toBe("bytes");
+    });
+
+    it("ignores Range on download so the saved file is complete", async () => {
+        selectRecording(recordingRow());
+
+        const response = await getAudio(
+            new Request(
+                "http://localhost/api/recordings/rec-1/audio?download=1",
+                { headers: { Range: "bytes=0-3" } },
+            ),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe("audio-bytes");
+        expect(response.headers.get("Content-Range")).toBeNull();
+    });
+
+    it("returns 404 for another user's recording", async () => {
+        selectRecording(null);
+
+        const response = await getAudio(
+            new Request(
+                "http://localhost/api/recordings/rec-1/audio?download=1",
+            ),
+            routeParams(),
+        );
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toMatchObject({
+            code: ErrorCode.RECORDING_NOT_FOUND,
+        });
+        expect(createUserStorageProvider).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Web-app download of the original audio file, and inline rename of recording titles. Both were missing on main: playback already streamed the file, and titles could only change via Plaud re-sync or auto-title.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Closes #229
Closes #217

## Changes Made

- `GET /api/recordings/[id]/audio?download=1` returns `Content-Disposition: attachment` with a title-derived filename and the stored extension. Range is ignored so the saved file is complete. Playback without the query param is unchanged.
- `PATCH /api/recordings/[id]` `{ filename }` persists a new title (encrypted at rest, user-scoped, tombstone-aware) and emits `recording.updated`.
- Player header: click-to-edit title + download button. Recording page heading is also editable. Row menu: Download audio.
- Filename sanitization shared in `src/lib/recordings/filename.ts`.

## Review follow-up (Cubic / Greptile)

- Dashboard `filenameOverrides` now last only until the next `recordings` snapshot, so sync or another client can update the title.
- Playback lifecycle keys off `recording.id` so rename / dialog / transcription state updates do not reset the player.
- PATCH rejects a JSON `null` (or non-object) body with 400 instead of throwing.
- IME composition Enter does not submit the rename.
- 404 rename test captures the `where` predicate and asserts `userId` + `deletedAt`.
- Windows reserved download basenames (`CON`, `LPT1`, …) are prefixed, including titles that already end with the audio extension.

## Testing

- `pnpm format-and-lint` (pre-existing infos in `elevated-cookie.test.ts` only)
- `pnpm type-check`
- `pnpm test` — 891 passed, 10 skipped

### Test Steps
1. Open a recording in the dashboard, click the title, rename, press Enter, reload. Title should stick.
2. Click the download icon (or row menu → Download audio). Browser should save the original file named from the title (e.g. `Planning Call.mp3`).
3. Confirm in-app playback still works (no download prompt).
4. After an inline rename, trigger a sync (or change the title from another client) and confirm the dashboard shows the refreshed server title, not the old overlay.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)

## Additional Notes

Rename is Riffado-local. A later Plaud version bump can still overwrite the title, same as auto-generated titles when sync-to-Plaud is off. Download uses the existing proxied audio route (full file buffered, same as playback).

## For Reviewers

- User-scoped `userId` + `deletedAt` on both the download path and PATCH.
- Title encrypted at rest via `encryptText`.
- No schema or env changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9204b45e-3f4f-47f9-a5a2-b7c9d6f729a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9204b45e-3f4f-47f9-a5a2-b7c9d6f729a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Download the original recording audio and allow inline renaming of recording titles. Previously playback only streamed and titles changed via Plaud sync/auto-title; now users can save the full file and rename titles directly without affecting playback.

- GET `/api/recordings/[id]/audio?download=1` returns an attachment named from the title and stored extension, sanitized and RFC 5987-compatible; ignores Range so the saved file is complete. Playback without `download` still supports Range and uses immutable caching; downloads use `Cache-Control: private, no-store`.
- PATCH `/api/recordings/[id]` accepts `{ filename }`, trims and strips control chars, max 200, rejects JSON null, encrypts at rest, and emits `recording.updated`. Request is user-scoped and tombstone-aware; response returns `{ filename }`.
- UI: Titles are click-to-edit in the player header and recording page; header and list row menu add “Download audio”. Inline renames update optimistically and are dropped on the next refresh so server truth (sync/other client) wins; playback now keys off `recording.id` so title edits do not remount audio or interrupt playback.
- Filenames: Windows reserved basenames are prefixed in downloads; shared sanitization in `src/lib/recordings/filename.ts`.
- No schema or env changes; no migration actions.

<sup>Written for commit cbd1fb9c086e327ba3130905819d1838c9a3197a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

