### PR TITLE
fix(transcription): stop long recordings dying at the 10-minute OpenAI timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,7 +84,10 @@ ENCRYPTION_KEY=your-64-char-hex-encryption-key-here
 # provider's 25 MiB hard limit. Audio above it is re-encoded to mono Opus,
 # starting at the configured bitrate and adapting
 # downward when needed to stay below the provider's 25 MiB hard limit.
-# The request timeout applies only to audio transcription calls.
+# WHISPER_REQUEST_TIMEOUT_MS applies to Whisper-style
+# /v1/audio/transcriptions and chat-style (OpenRouter) transcription.
+# Default 3600000 (60 min). The OpenAI Node SDK default is 10 min, which
+# aborts long recordings even when the provider is still working.
 # WHISPER_MAX_BYTES=25165824
 # WHISPER_COMPRESS_BITRATE_KBPS=12
 # WHISPER_REQUEST_TIMEOUT_MS=3600000

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -168,7 +168,7 @@ const baseEnvSchema = z.object({
         .transform((val) => (val ? Number(val) : 12))
         .pipe(z.number().int().positive()),
 
-    /** OpenAI-style audio transcription request timeout in milliseconds. */
+    /** OpenAI-compatible transcription request timeout (Whisper and chat-style). */
     WHISPER_REQUEST_TIMEOUT_MS: z
         .string()
         .regex(/^\d+$/, "WHISPER_REQUEST_TIMEOUT_MS must be a positive integer")

--- a/src/lib/transcription/chat-transcribe.ts
+++ b/src/lib/transcription/chat-transcribe.ts
@@ -1,4 +1,5 @@
 import type { OpenAI } from "openai";
+import { env } from "@/lib/env";
 
 export interface ChatTranscribeArgs {
     client: OpenAI;
@@ -50,24 +51,27 @@ export async function chatTranscribe({
         ? `${TRANSCRIBE_INSTRUCTION} The audio language is ${language}.`
         : TRANSCRIBE_INSTRUCTION;
 
-    const response = await client.chat.completions.create({
-        model,
-        messages: [
-            {
-                role: "user",
-                content: [
-                    { type: "text", text: prompt },
-                    {
-                        type: "input_audio",
-                        input_audio: { data, format },
-                    } as unknown as {
-                        type: "text";
-                        text: string;
-                    },
-                ],
-            },
-        ],
-    });
+    const response = await client.chat.completions.create(
+        {
+            model,
+            messages: [
+                {
+                    role: "user",
+                    content: [
+                        { type: "text", text: prompt },
+                        {
+                            type: "input_audio",
+                            input_audio: { data, format },
+                        } as unknown as {
+                            type: "text";
+                            text: string;
+                        },
+                    ],
+                },
+            ],
+        },
+        { timeout: env.WHISPER_REQUEST_TIMEOUT_MS },
+    );
 
     const text = response.choices?.[0]?.message?.content;
     if (typeof text !== "string" || text.trim() === "") {

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -433,6 +433,7 @@ export async function transcribeRecording(
                 const openai = new OpenAI({
                     apiKey,
                     baseURL: credentials.baseUrl || undefined,
+                    timeout: env.WHISPER_REQUEST_TIMEOUT_MS,
                 });
 
                 if (transcriptionStyle === "chat") {

--- a/src/tests/regressions/122-openrouter-transcription.test.ts
+++ b/src/tests/regressions/122-openrouter-transcription.test.ts
@@ -213,6 +213,12 @@ describe("issue #122 — OpenRouter transcription uses chat-completions", () => 
         expect(result.success).toBe(true);
         expect(audioCreate).not.toHaveBeenCalled();
         expect(chatCreate).toHaveBeenCalledTimes(1);
+        expect(OpenAI).toHaveBeenCalledWith(
+            expect.objectContaining({ timeout: 60 * 60 * 1000 }),
+        );
+        expect(chatCreate.mock.calls[0]?.[1]).toEqual({
+            timeout: 60 * 60 * 1000,
+        });
 
         const chatArgs = chatCreate.mock.calls[0]?.[0];
         expect(chatArgs?.model).toBe("google/gemini-2.5-flash-lite");

--- a/src/tests/regressions/219-transcription-timeout.test.ts
+++ b/src/tests/regressions/219-transcription-timeout.test.ts
@@ -12,10 +12,8 @@
 import type { OpenAI } from "openai";
 import { describe, expect, it, vi } from "vitest";
 
-const TIMEOUT_MS = 60 * 60 * 1000;
-
 vi.mock("@/lib/env", () => ({
-    env: { WHISPER_REQUEST_TIMEOUT_MS: TIMEOUT_MS },
+    env: { WHISPER_REQUEST_TIMEOUT_MS: 60 * 60 * 1000 },
 }));
 
 import { chatTranscribe } from "@/lib/transcription/chat-transcribe";
@@ -38,6 +36,8 @@ describe("issue #219 — chat-style transcription uses the long request timeout"
 
         expect(result.text).toBe("hello from chat");
         expect(create).toHaveBeenCalledTimes(1);
-        expect(create.mock.calls[0]?.[1]).toEqual({ timeout: TIMEOUT_MS });
+        expect(create.mock.calls[0]?.[1]).toEqual({
+            timeout: 60 * 60 * 1000,
+        });
     });
 });

--- a/src/tests/regressions/219-transcription-timeout.test.ts
+++ b/src/tests/regressions/219-transcription-timeout.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression: issue #219
+ *
+ * The OpenAI Node SDK defaults to a 10-minute request timeout. Long
+ * recordings die in the UI with "request timed out" even when the
+ * provider later finishes. Whisper-style already overrides per-request
+ * via WHISPER_REQUEST_TIMEOUT_MS (default 60 min, #183). The chat-style
+ * path (OpenRouter) used the same client without a timeout and hit the
+ * same 10-minute abort.
+ */
+
+import type { OpenAI } from "openai";
+import { describe, expect, it, vi } from "vitest";
+
+const TIMEOUT_MS = 60 * 60 * 1000;
+
+vi.mock("@/lib/env", () => ({
+    env: { WHISPER_REQUEST_TIMEOUT_MS: TIMEOUT_MS },
+}));
+
+import { chatTranscribe } from "@/lib/transcription/chat-transcribe";
+
+describe("issue #219 — chat-style transcription uses the long request timeout", () => {
+    it("passes WHISPER_REQUEST_TIMEOUT_MS to chat.completions.create", async () => {
+        const create = vi.fn().mockResolvedValue({
+            choices: [{ message: { content: "hello from chat" } }],
+        });
+        const client = {
+            chat: { completions: { create } },
+        } as unknown as OpenAI;
+
+        const result = await chatTranscribe({
+            client,
+            model: "google/gemini-2.5-flash-lite",
+            audioBuffer: Buffer.from("fake-mp3"),
+            contentType: "audio/mpeg",
+        });
+
+        expect(result.text).toBe("hello from chat");
+        expect(create).toHaveBeenCalledTimes(1);
+        expect(create.mock.calls[0]?.[1]).toEqual({ timeout: TIMEOUT_MS });
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Long recordings were aborting with "request timed out" because the OpenAI Node SDK defaults to 10 minutes. Whisper-style already overrode that via `WHISPER_REQUEST_TIMEOUT_MS` (60 min default, from #183). The client constructor and the chat-style OpenRouter path still used the SDK default.

This PR reuses the existing env knob instead of adding `TRANSCRIPTION_TIMEOUT_MS`. Same 60-minute default, one setting for both transcription styles.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #219

## Changes Made

- Set `timeout: env.WHISPER_REQUEST_TIMEOUT_MS` on the transcription `OpenAI` client
- Pass the same timeout to `chat.completions.create` in `chat-transcribe.ts`
- Document that the knob applies to Whisper-style and chat-style (OpenRouter) calls
- Regression test for #219; assert the timeout on the #122 OpenRouter path

## Testing

- `pnpm format-and-lint:fix && pnpm type-check` (pass)
- `pnpm test src/tests/regressions/219-transcription-timeout.test.ts src/tests/regressions/122-openrouter-transcription.test.ts` (pass)

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] Type checking passes (`pnpm type-check`)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally (`pnpm test` on the touched regressions)

## Additional Notes

Did not introduce a second env var. `WHISPER_REQUEST_TIMEOUT_MS` already ships with the 60-minute default the issue asked for. Gemini stays out of scope (different SDK).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf47e2d2-e13d-4dee-9dc3-0c643e1b5aa1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf47e2d2-e13d-4dee-9dc3-0c643e1b5aa1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop long transcriptions failing at 10 minutes by applying `WHISPER_REQUEST_TIMEOUT_MS` to chat-style (OpenRouter) requests and the `OpenAI` client. Previously chat-style timed out at 10 minutes; now both paths use the same configurable timeout (60-minute default).

**Bug Fixes**
- Set `timeout` on the `OpenAI` client from `WHISPER_REQUEST_TIMEOUT_MS`.
- Pass the same timeout to `chat.completions.create`.
- Clarify in `.env.example` and update the `env.ts` JSDoc that the env var covers both paths.
- Add a regression test for the chat path and update the mock to inline the timeout so Vitest hoisting works.
- Extend the OpenRouter test to assert the client and chat call receive the 60-minute timeout.

<sup>Written for commit 0d117a59502a3d5ee89edbcf737738c3e93b22c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

