### PR TITLE
fix(transcription): sniff Plaud Ogg/Opus and transcode for OpenRouter

### DIFF
--- a/src/lib/audio/sniff.ts
+++ b/src/lib/audio/sniff.ts
@@ -1,0 +1,140 @@
+export type AudioContainer =
+    | "ogg"
+    | "mp3"
+    | "wav"
+    | "mp4"
+    | "flac"
+    | "webm"
+    | "unknown";
+
+export type AudioCodec =
+    | "opus"
+    | "vorbis"
+    | "mp3"
+    | "pcm"
+    | "aac"
+    | "flac"
+    | "unknown";
+
+export interface SniffedAudio {
+    container: AudioContainer;
+    codec: AudioCodec;
+    extension: string;
+    contentType: string;
+}
+
+/**
+ * Detect audio container and codec from magic bytes, ignoring filename.
+ * Plaud often labels Ogg/Opus downloads as `.mp3`.
+ */
+export function sniffAudio(buffer: Buffer): SniffedAudio {
+    if (isOggContainer(buffer)) {
+        return buildSniff("ogg", detectOggCodec(buffer));
+    }
+    if (isWavContainer(buffer)) {
+        return buildSniff("wav", "pcm");
+    }
+    if (isFlacContainer(buffer)) {
+        return buildSniff("flac", "flac");
+    }
+    if (isMp4Container(buffer)) {
+        return buildSniff("mp4", "aac");
+    }
+    if (isWebmContainer(buffer)) {
+        return buildSniff("webm", "unknown");
+    }
+    if (isMp3Container(buffer)) {
+        return buildSniff("mp3", "mp3");
+    }
+    return buildSniff("unknown", "unknown");
+}
+
+export function isOggContainer(buffer: Buffer): boolean {
+    return (
+        buffer.length >= 4 &&
+        buffer[0] === 0x4f &&
+        buffer[1] === 0x67 &&
+        buffer[2] === 0x67 &&
+        buffer[3] === 0x53
+    );
+}
+
+function isWavContainer(buffer: Buffer): boolean {
+    return (
+        buffer.length >= 12 &&
+        buffer.toString("ascii", 0, 4) === "RIFF" &&
+        buffer.toString("ascii", 8, 12) === "WAVE"
+    );
+}
+
+function isFlacContainer(buffer: Buffer): boolean {
+    return buffer.length >= 4 && buffer.toString("ascii", 0, 4) === "fLaC";
+}
+
+function isMp4Container(buffer: Buffer): boolean {
+    return buffer.length >= 8 && buffer.toString("ascii", 4, 8) === "ftyp";
+}
+
+function isWebmContainer(buffer: Buffer): boolean {
+    return (
+        buffer.length >= 4 &&
+        buffer[0] === 0x1a &&
+        buffer[1] === 0x45 &&
+        buffer[2] === 0xdf &&
+        buffer[3] === 0xa3
+    );
+}
+
+function isMp3Container(buffer: Buffer): boolean {
+    if (
+        buffer.length >= 3 &&
+        buffer[0] === 0x49 &&
+        buffer[1] === 0x44 &&
+        buffer[2] === 0x33
+    ) {
+        return true;
+    }
+    return (
+        buffer.length >= 2 && buffer[0] === 0xff && (buffer[1] & 0xe0) === 0xe0
+    );
+}
+
+function detectOggCodec(buffer: Buffer): AudioCodec {
+    if (buffer.includes(Buffer.from("OpusHead"))) return "opus";
+    if (buffer.includes(Buffer.from("\x01vorbis"))) return "vorbis";
+    return "unknown";
+}
+
+function buildSniff(
+    container: AudioContainer,
+    codec: AudioCodec,
+): SniffedAudio {
+    const { extension, contentType } = metaForContainer(container);
+    return { container, codec, extension, contentType };
+}
+
+function metaForContainer(container: AudioContainer): {
+    extension: string;
+    contentType: string;
+} {
+    switch (container) {
+        case "ogg":
+            return { extension: "ogg", contentType: "audio/ogg" };
+        case "mp3":
+            return { extension: "mp3", contentType: "audio/mpeg" };
+        case "wav":
+            return { extension: "wav", contentType: "audio/wav" };
+        case "mp4":
+            return { extension: "m4a", contentType: "audio/mp4" };
+        case "flac":
+            return { extension: "flac", contentType: "audio/flac" };
+        case "webm":
+            return { extension: "webm", contentType: "audio/webm" };
+        case "unknown":
+            return { extension: "mp3", contentType: "audio/mpeg" };
+        default: {
+            const _never: never = container;
+            throw new Error(`unhandled audio container: ${_never}`);
+        }
+    }
+}

--- a/src/lib/audio/sniff.ts
+++ b/src/lib/audio/sniff.ts
@@ -4,6 +4,7 @@ export type AudioContainer =
     | "wav"
     | "mp4"
     | "flac"
+    | "aac"
     | "webm"
     | "unknown";
 
@@ -42,6 +43,9 @@ export function sniffAudio(buffer: Buffer): SniffedAudio {
     }
     if (isWebmContainer(buffer)) {
         return buildSniff("webm", "unknown");
+    }
+    if (isAdtsAac(buffer)) {
+        return buildSniff("aac", "aac");
     }
     if (isMp3Container(buffer)) {
         return buildSniff("mp3", "mp3");
@@ -85,6 +89,16 @@ function isWebmContainer(buffer: Buffer): boolean {
     );
 }
 
+function mpegLayerBits(secondByte: number): number {
+    return (secondByte >> 1) & 0x03;
+}
+
+function isAdtsAac(buffer: Buffer): boolean {
+    if (buffer.length < 2 || buffer[0] !== 0xff) return false;
+    if ((buffer[1] & 0xf0) !== 0xf0) return false;
+    return mpegLayerBits(buffer[1]) === 0;
+}
+
 function isMp3Container(buffer: Buffer): boolean {
     if (
         buffer.length >= 3 &&
@@ -94,9 +108,9 @@ function isMp3Container(buffer: Buffer): boolean {
     ) {
         return true;
     }
-    return (
-        buffer.length >= 2 && buffer[0] === 0xff && (buffer[1] & 0xe0) === 0xe0
-    );
+    if (buffer.length < 2 || buffer[0] !== 0xff) return false;
+    if ((buffer[1] & 0xe0) !== 0xe0) return false;
+    return mpegLayerBits(buffer[1]) !== 0;
 }
 
 function detectOggCodec(buffer: Buffer): AudioCodec {
@@ -128,6 +142,8 @@ function metaForContainer(container: AudioContainer): {
             return { extension: "m4a", contentType: "audio/mp4" };
         case "flac":
             return { extension: "flac", contentType: "audio/flac" };
+        case "aac":
+            return { extension: "aac", contentType: "audio/aac" };
         case "webm":
             return { extension: "webm", contentType: "audio/webm" };
         case "unknown":

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -81,6 +81,73 @@ interface SyncContext {
     barkNotifications: boolean;
     notificationEmail: string | null;
     barkPushUrl: string | null;
+    storageKeys: StorageKeyAllocator;
+}
+
+class StorageKeyAllocator {
+    private readonly reserved = new Set<string>();
+    private tail: Promise<void> = Promise.resolve();
+
+    allocate(
+        userId: string,
+        baseName: string,
+        ext: string,
+        plaudFileId: string,
+    ): Promise<string> {
+        return this.enqueue(() =>
+            this.pickKey(userId, baseName, ext, plaudFileId),
+        );
+    }
+
+    reuse(storagePath: string): Promise<string> {
+        return this.enqueue(() => {
+            this.reserved.add(storagePath);
+            return storagePath;
+        });
+    }
+
+    private enqueue<T>(fn: () => Promise<T> | T): Promise<T> {
+        const run = this.tail.then(fn, fn);
+        this.tail = run.then(
+            () => undefined,
+            () => undefined,
+        );
+        return run;
+    }
+
+    private async pickKey(
+        userId: string,
+        baseName: string,
+        ext: string,
+        plaudFileId: string,
+    ): Promise<string> {
+        const candidate = (suffix: string) =>
+            `${userId}/${baseName}${suffix}.${ext}`;
+
+        for (let i = 0; i < 100; i++) {
+            const suffix = i === 0 ? "" : ` (${i + 1})`;
+            const key = candidate(suffix);
+            if (this.reserved.has(key)) continue;
+            const [existing] = await db
+                .select({ id: recordings.id })
+                .from(recordings)
+                .where(
+                    and(
+                        eq(recordings.userId, userId),
+                        eq(recordings.storagePath, key),
+                        ne(recordings.plaudFileId, plaudFileId),
+                    ),
+                )
+                .limit(1);
+            if (!existing) {
+                this.reserved.add(key);
+                return key;
+            }
+        }
+        const fallback = `${userId}/${plaudFileId}.${ext}`;
+        this.reserved.add(fallback);
+        return fallback;
+    }
 }
 
 /** A freshly-synced recording that Plaud may hold transcript/summary content
@@ -90,34 +157,6 @@ interface ImportCandidate {
     plaudFileId: string;
     isTrans: boolean;
     isSummary: boolean;
-}
-
-async function uniqueStorageKey(
-    userId: string,
-    baseName: string,
-    ext: string,
-    plaudFileId: string,
-): Promise<string> {
-    const candidate = (suffix: string) =>
-        `${userId}/${baseName}${suffix}.${ext}`;
-
-    for (let i = 0; i < 100; i++) {
-        const suffix = i === 0 ? "" : ` (${i + 1})`;
-        const key = candidate(suffix);
-        const [existing] = await db
-            .select({ id: recordings.id })
-            .from(recordings)
-            .where(
-                and(
-                    eq(recordings.userId, userId),
-                    eq(recordings.storagePath, key),
-                    ne(recordings.plaudFileId, plaudFileId),
-                ),
-            )
-            .limit(1);
-        if (!existing) return key;
-    }
-    return `${userId}/${plaudFileId}.${ext}`;
 }
 
 async function storagePathHeldByOtherRecording(
@@ -140,7 +179,7 @@ async function storagePathHeldByOtherRecording(
 }
 
 async function resolveStorageKey(
-    userId: string,
+    context: SyncContext,
     existingRecording: { id: string; storagePath: string | null } | undefined,
     safeName: string,
     fileExtension: string,
@@ -148,13 +187,26 @@ async function resolveStorageKey(
 ): Promise<string> {
     if (existingRecording?.storagePath) {
         const shared = await storagePathHeldByOtherRecording(
-            userId,
+            context.userId,
             existingRecording.storagePath,
             existingRecording.id,
         );
-        if (!shared) return existingRecording.storagePath;
+        if (!shared) {
+            return context.storageKeys.reuse(existingRecording.storagePath);
+        }
+        return context.storageKeys.allocate(
+            context.userId,
+            plaudFileId,
+            fileExtension,
+            plaudFileId,
+        );
     }
-    return uniqueStorageKey(userId, safeName, fileExtension, plaudFileId);
+    return context.storageKeys.allocate(
+        context.userId,
+        safeName,
+        fileExtension,
+        plaudFileId,
+    );
 }
 
 /**
@@ -256,7 +308,7 @@ async function processRecording(
             plaudRecording.filename.replace(/[/\\:*?"<>|]/g, "-").trim() ||
             plaudRecording.id;
         const storageKey = await resolveStorageKey(
-            context.userId,
+            context,
             existingRecording,
             safeName,
             fileExtension,
@@ -558,6 +610,7 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
             notificationEmail:
                 settings?.notificationEmail || user?.email || null,
             barkPushUrl: settings?.barkPushUrl || null,
+            storageKeys: new StorageKeyAllocator(),
         };
 
         const plaudClient = await createPlaudClient(

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -81,73 +81,6 @@ interface SyncContext {
     barkNotifications: boolean;
     notificationEmail: string | null;
     barkPushUrl: string | null;
-    storageKeys: StorageKeyAllocator;
-}
-
-class StorageKeyAllocator {
-    private readonly reserved = new Set<string>();
-    private tail: Promise<void> = Promise.resolve();
-
-    allocate(
-        userId: string,
-        baseName: string,
-        ext: string,
-        plaudFileId: string,
-    ): Promise<string> {
-        return this.enqueue(() =>
-            this.pickKey(userId, baseName, ext, plaudFileId),
-        );
-    }
-
-    reuse(storagePath: string): Promise<string> {
-        return this.enqueue(() => {
-            this.reserved.add(storagePath);
-            return storagePath;
-        });
-    }
-
-    private enqueue<T>(fn: () => Promise<T> | T): Promise<T> {
-        const run = this.tail.then(fn, fn);
-        this.tail = run.then(
-            () => undefined,
-            () => undefined,
-        );
-        return run;
-    }
-
-    private async pickKey(
-        userId: string,
-        baseName: string,
-        ext: string,
-        plaudFileId: string,
-    ): Promise<string> {
-        const candidate = (suffix: string) =>
-            `${userId}/${baseName}${suffix}.${ext}`;
-
-        for (let i = 0; i < 100; i++) {
-            const suffix = i === 0 ? "" : ` (${i + 1})`;
-            const key = candidate(suffix);
-            if (this.reserved.has(key)) continue;
-            const [existing] = await db
-                .select({ id: recordings.id })
-                .from(recordings)
-                .where(
-                    and(
-                        eq(recordings.userId, userId),
-                        eq(recordings.storagePath, key),
-                        ne(recordings.plaudFileId, plaudFileId),
-                    ),
-                )
-                .limit(1);
-            if (!existing) {
-                this.reserved.add(key);
-                return key;
-            }
-        }
-        const fallback = `${userId}/${plaudFileId}.${ext}`;
-        this.reserved.add(fallback);
-        return fallback;
-    }
 }
 
 /** A freshly-synced recording that Plaud may hold transcript/summary content
@@ -178,35 +111,48 @@ async function storagePathHeldByOtherRecording(
     return Boolean(other);
 }
 
+async function allocateStorageKey(
+    userId: string,
+    plaudFileId: string,
+    ext: string,
+): Promise<string> {
+    const candidate = (suffix: string) =>
+        `${userId}/${plaudFileId}${suffix}.${ext}`;
+
+    for (let i = 0; i < 100; i++) {
+        const suffix = i === 0 ? "" : ` (${i + 1})`;
+        const key = candidate(suffix);
+        const [existing] = await db
+            .select({ id: recordings.id })
+            .from(recordings)
+            .where(
+                and(
+                    eq(recordings.userId, userId),
+                    eq(recordings.storagePath, key),
+                    ne(recordings.plaudFileId, plaudFileId),
+                ),
+            )
+            .limit(1);
+        if (!existing) return key;
+    }
+    return `${userId}/${plaudFileId}.${ext}`;
+}
+
 async function resolveStorageKey(
-    context: SyncContext,
+    userId: string,
     existingRecording: { id: string; storagePath: string | null } | undefined,
-    safeName: string,
     fileExtension: string,
     plaudFileId: string,
 ): Promise<string> {
     if (existingRecording?.storagePath) {
         const shared = await storagePathHeldByOtherRecording(
-            context.userId,
+            userId,
             existingRecording.storagePath,
             existingRecording.id,
         );
-        if (!shared) {
-            return context.storageKeys.reuse(existingRecording.storagePath);
-        }
-        return context.storageKeys.allocate(
-            context.userId,
-            plaudFileId,
-            fileExtension,
-            plaudFileId,
-        );
+        if (!shared) return existingRecording.storagePath;
     }
-    return context.storageKeys.allocate(
-        context.userId,
-        safeName,
-        fileExtension,
-        plaudFileId,
-    );
+    return allocateStorageKey(userId, plaudFileId, fileExtension);
 }
 
 /**
@@ -304,13 +250,9 @@ async function processRecording(
 
         const sniffed = sniffAudio(audioBuffer);
         const fileExtension = sniffed.extension;
-        const safeName =
-            plaudRecording.filename.replace(/[/\\:*?"<>|]/g, "-").trim() ||
-            plaudRecording.id;
         const storageKey = await resolveStorageKey(
-            context,
+            context.userId,
             existingRecording,
-            safeName,
             fileExtension,
             plaudRecording.id,
         );
@@ -610,7 +552,6 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
             notificationEmail:
                 settings?.notificationEmail || user?.email || null,
             barkPushUrl: settings?.barkPushUrl || null,
-            storageKeys: new StorageKeyAllocator(),
         };
 
         const plaudClient = await createPlaudClient(

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -120,6 +120,43 @@ async function uniqueStorageKey(
     return `${userId}/${plaudFileId}.${ext}`;
 }
 
+async function storagePathHeldByOtherRecording(
+    userId: string,
+    storagePath: string,
+    exceptRecordingId: string,
+): Promise<boolean> {
+    const [other] = await db
+        .select({ id: recordings.id })
+        .from(recordings)
+        .where(
+            and(
+                eq(recordings.userId, userId),
+                eq(recordings.storagePath, storagePath),
+                ne(recordings.id, exceptRecordingId),
+            ),
+        )
+        .limit(1);
+    return Boolean(other);
+}
+
+async function resolveStorageKey(
+    userId: string,
+    existingRecording: { id: string; storagePath: string | null } | undefined,
+    safeName: string,
+    fileExtension: string,
+    plaudFileId: string,
+): Promise<string> {
+    if (existingRecording?.storagePath) {
+        const shared = await storagePathHeldByOtherRecording(
+            userId,
+            existingRecording.storagePath,
+            existingRecording.id,
+        );
+        if (!shared) return existingRecording.storagePath;
+    }
+    return uniqueStorageKey(userId, safeName, fileExtension, plaudFileId);
+}
+
 /**
  * Build an import candidate for a freshly-synced recording, or `undefined`
  * when there's nothing to import — the recording is trashed, or Plaud reports
@@ -218,14 +255,13 @@ async function processRecording(
         const safeName =
             plaudRecording.filename.replace(/[/\\:*?"<>|]/g, "-").trim() ||
             plaudRecording.id;
-        const storageKey =
-            existingRecording?.storagePath ??
-            (await uniqueStorageKey(
-                context.userId,
-                safeName,
-                fileExtension,
-                plaudRecording.id,
-            ));
+        const storageKey = await resolveStorageKey(
+            context.userId,
+            existingRecording,
+            safeName,
+            fileExtension,
+            plaudRecording.id,
+        );
         const contentType = sniffed.contentType;
         await storage.uploadFile(storageKey, audioBuffer, contentType);
 

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -290,6 +290,18 @@ async function processRecording(
                 return { status: "skipped" };
             }
 
+            const previousPath = existingRecording.storagePath;
+            if (previousPath && previousPath !== storageKey) {
+                try {
+                    await storage.deleteFile(previousPath);
+                } catch (cleanupError) {
+                    console.error(
+                        `Failed to delete replaced storage object ${previousPath}:`,
+                        cleanupError,
+                    );
+                }
+            }
+
             await emitEvent(
                 "recording.updated",
                 context.userId,

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -135,7 +135,9 @@ async function allocateStorageKey(
             .limit(1);
         if (!existing) return key;
     }
-    return `${userId}/${plaudFileId}.${ext}`;
+    throw new Error(
+        "Unable to allocate a unique storage key for Plaud recording",
+    );
 }
 
 async function resolveStorageKey(

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -120,25 +120,6 @@ async function uniqueStorageKey(
     return `${userId}/${plaudFileId}.${ext}`;
 }
 
-async function storagePathHeldByOtherRecording(
-    userId: string,
-    storagePath: string,
-    exceptRecordingId: string,
-): Promise<boolean> {
-    const [held] = await db
-        .select({ id: recordings.id })
-        .from(recordings)
-        .where(
-            and(
-                eq(recordings.userId, userId),
-                eq(recordings.storagePath, storagePath),
-                ne(recordings.id, exceptRecordingId),
-            ),
-        )
-        .limit(1);
-    return !!held;
-}
-
 /**
  * Build an import candidate for a freshly-synced recording, or `undefined`
  * when there's nothing to import — the recording is trashed, or Plaud reports
@@ -237,12 +218,14 @@ async function processRecording(
         const safeName =
             plaudRecording.filename.replace(/[/\\:*?"<>|]/g, "-").trim() ||
             plaudRecording.id;
-        const storageKey = await uniqueStorageKey(
-            context.userId,
-            safeName,
-            fileExtension,
-            plaudRecording.id,
-        );
+        const storageKey =
+            existingRecording?.storagePath ??
+            (await uniqueStorageKey(
+                context.userId,
+                safeName,
+                fileExtension,
+                plaudRecording.id,
+            ));
         const contentType = sniffed.contentType;
         await storage.uploadFile(storageKey, audioBuffer, contentType);
 
@@ -307,25 +290,6 @@ async function processRecording(
                     );
                 }
                 return { status: "skipped" };
-            }
-
-            const previousPath = existingRecording.storagePath;
-            if (previousPath && previousPath !== storageKey) {
-                const shared = await storagePathHeldByOtherRecording(
-                    context.userId,
-                    previousPath,
-                    existingRecording.id,
-                );
-                if (!shared) {
-                    try {
-                        await storage.deleteFile(previousPath);
-                    } catch (cleanupError) {
-                        console.error(
-                            `Failed to delete replaced storage object ${previousPath}:`,
-                            cleanupError,
-                        );
-                    }
-                }
             }
 
             await emitEvent(

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -8,6 +8,7 @@ import {
     userSettings,
     users,
 } from "@/db/schema";
+import { sniffAudio } from "@/lib/audio/sniff";
 import { encryptText } from "@/lib/encryption/fields";
 import { isHostedLockedOut } from "@/lib/entitlements";
 import { env } from "@/lib/env";
@@ -212,7 +213,8 @@ async function processRecording(
             false,
         );
 
-        const fileExtension = "mp3";
+        const sniffed = sniffAudio(audioBuffer);
+        const fileExtension = sniffed.extension;
         const safeName =
             plaudRecording.filename.replace(/[/\\:*?"<>|]/g, "-").trim() ||
             plaudRecording.id;
@@ -222,7 +224,7 @@ async function processRecording(
             fileExtension,
             plaudRecording.id,
         );
-        const contentType = "audio/mpeg";
+        const contentType = sniffed.contentType;
         await storage.uploadFile(storageKey, audioBuffer, contentType);
 
         const recordingData = {

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -120,6 +120,25 @@ async function uniqueStorageKey(
     return `${userId}/${plaudFileId}.${ext}`;
 }
 
+async function storagePathHeldByOtherRecording(
+    userId: string,
+    storagePath: string,
+    exceptRecordingId: string,
+): Promise<boolean> {
+    const [held] = await db
+        .select({ id: recordings.id })
+        .from(recordings)
+        .where(
+            and(
+                eq(recordings.userId, userId),
+                eq(recordings.storagePath, storagePath),
+                ne(recordings.id, exceptRecordingId),
+            ),
+        )
+        .limit(1);
+    return !!held;
+}
+
 /**
  * Build an import candidate for a freshly-synced recording, or `undefined`
  * when there's nothing to import — the recording is trashed, or Plaud reports
@@ -292,13 +311,20 @@ async function processRecording(
 
             const previousPath = existingRecording.storagePath;
             if (previousPath && previousPath !== storageKey) {
-                try {
-                    await storage.deleteFile(previousPath);
-                } catch (cleanupError) {
-                    console.error(
-                        `Failed to delete replaced storage object ${previousPath}:`,
-                        cleanupError,
-                    );
+                const shared = await storagePathHeldByOtherRecording(
+                    context.userId,
+                    previousPath,
+                    existingRecording.id,
+                );
+                if (!shared) {
+                    try {
+                        await storage.deleteFile(previousPath);
+                    } catch (cleanupError) {
+                        console.error(
+                            `Failed to delete replaced storage object ${previousPath}:`,
+                            cleanupError,
+                        );
+                    }
                 }
             }
 

--- a/src/lib/transcription/audio-file.ts
+++ b/src/lib/transcription/audio-file.ts
@@ -1,18 +1,9 @@
+import { sniffAudio } from "@/lib/audio/sniff";
 import { getAudioMimeType } from "@/lib/utils";
 
 export interface BuildAudioFileResult {
     file: File;
     contentType: string;
-}
-
-function isOggContainer(audioBuffer: Buffer): boolean {
-    if (audioBuffer.length < 4) return false;
-    return (
-        audioBuffer[0] === 0x4f &&
-        audioBuffer[1] === 0x67 &&
-        audioBuffer[2] === 0x67 &&
-        audioBuffer[3] === 0x53
-    );
 }
 
 /** Build the `File` passed to `openai.audio.transcriptions.create`. */
@@ -21,17 +12,16 @@ export function buildAudioFile(
     storagePath: string,
     decryptedFilename: string,
 ): BuildAudioFileResult {
-    const isOgg = isOggContainer(audioBuffer);
-
-    const ext = isOgg
-        ? "ogg"
+    const sniffed = sniffAudio(audioBuffer);
+    const known = sniffed.container !== "unknown";
+    const ext = known
+        ? sniffed.extension
         : storagePath.split(".").pop()?.toLowerCase() || "mp3";
+    const contentType = known
+        ? sniffed.contentType
+        : getAudioMimeType(storagePath);
 
-    const contentType = isOgg ? "audio/ogg" : getAudioMimeType(storagePath);
-
-    const filename = decryptedFilename.match(/\.\w{2,4}$/)
-        ? decryptedFilename
-        : `${decryptedFilename}.${ext}`;
+    const filename = withAudioExtension(decryptedFilename, ext);
 
     const view = new Uint8Array(
         audioBuffer.buffer as ArrayBuffer,
@@ -43,4 +33,11 @@ export function buildAudioFile(
     });
 
     return { file, contentType };
+}
+
+function withAudioExtension(name: string, ext: string): string {
+    if (/\.\w{2,4}$/.test(name)) {
+        return name.replace(/\.\w{2,4}$/, `.${ext}`);
+    }
+    return `${name}.${ext}`;
 }

--- a/src/lib/transcription/chat-transcribe.ts
+++ b/src/lib/transcription/chat-transcribe.ts
@@ -1,5 +1,7 @@
 import type { OpenAI } from "openai";
+import { sniffAudio } from "@/lib/audio/sniff";
 import { env } from "@/lib/env";
+import { transcodeToMp3 } from "@/lib/transcription/ffmpeg";
 
 export interface ChatTranscribeArgs {
     client: OpenAI;
@@ -24,11 +26,16 @@ function contentTypeToAudioFormat(contentType: string): "mp3" | "wav" {
 }
 
 export class ChatTranscribeFormatError extends Error {
-    constructor(public contentType: string) {
+    constructor(
+        public contentType: string,
+        cause?: string,
+    ) {
         super(
-            `This transcription provider only accepts mp3 or wav audio (got ${contentType}). ` +
-                `Re-upload as mp3/wav, or set a Whisper-compatible provider (OpenAI, Groq, Together AI, ` +
-                `or a local Whisper server) as your default for transcription.`,
+            cause
+                ? `This transcription provider only accepts mp3 or wav audio (got ${contentType}). Conversion to mp3 failed: ${cause}`
+                : `This transcription provider only accepts mp3 or wav audio (got ${contentType}). ` +
+                      `Re-upload as mp3/wav, or set a Whisper-compatible provider (OpenAI, Groq, Together AI, ` +
+                      `or a local Whisper server) as your default for transcription.`,
         );
         this.name = "ChatTranscribeFormatError";
     }
@@ -37,6 +44,31 @@ export class ChatTranscribeFormatError extends Error {
 const TRANSCRIBE_INSTRUCTION =
     "Transcribe the attached audio verbatim. Output only the transcript text — no preamble, no summary, no timestamps, no speaker labels, no markdown.";
 
+async function ensureChatCompatibleAudio(
+    audioBuffer: Buffer,
+    contentType: string,
+): Promise<{ buffer: Buffer; format: "mp3" | "wav" }> {
+    try {
+        return {
+            buffer: audioBuffer,
+            format: contentTypeToAudioFormat(contentType),
+        };
+    } catch (error) {
+        if (!(error instanceof ChatTranscribeFormatError)) throw error;
+        try {
+            const mp3 = await transcodeToMp3(audioBuffer);
+            return { buffer: mp3, format: "mp3" };
+        } catch (transcodeError) {
+            throw new ChatTranscribeFormatError(
+                contentType,
+                transcodeError instanceof Error
+                    ? transcodeError.message
+                    : String(transcodeError),
+            );
+        }
+    }
+}
+
 export async function chatTranscribe({
     client,
     model,
@@ -44,8 +76,14 @@ export async function chatTranscribe({
     contentType,
     language,
 }: ChatTranscribeArgs): Promise<ChatTranscribeResult> {
-    const format = contentTypeToAudioFormat(contentType);
-    const data = audioBuffer.toString("base64");
+    const sniffed = sniffAudio(audioBuffer);
+    const effectiveType =
+        sniffed.container === "unknown" ? contentType : sniffed.contentType;
+    const { buffer, format } = await ensureChatCompatibleAudio(
+        audioBuffer,
+        effectiveType,
+    );
+    const data = buffer.toString("base64");
 
     const prompt = language
         ? `${TRANSCRIBE_INSTRUCTION} The audio language is ${language}.`

--- a/src/lib/transcription/compress-audio.ts
+++ b/src/lib/transcription/compress-audio.ts
@@ -1,5 +1,5 @@
-import { spawn } from "node:child_process";
 import { env } from "@/lib/env";
+import { ffmpegToOpus } from "@/lib/transcription/ffmpeg";
 
 const MIN_BITRATE_KBPS = 6;
 const WHISPER_HARD_LIMIT_BYTES = 25 * 1024 * 1024;
@@ -80,78 +80,4 @@ export async function maybeCompressForWhisper(
 
 function formatMib(bytes: number): string {
     return `${(bytes / 1024 / 1024).toFixed(2)} MiB`;
-}
-
-function ffmpegToOpus(input: Buffer, bitrateKbps: number): Promise<Buffer> {
-    return new Promise((resolve, reject) => {
-        const ff = spawn(
-            "ffmpeg",
-            [
-                "-hide_banner",
-                "-loglevel",
-                "error",
-                "-i",
-                "pipe:0",
-                "-vn",
-                "-map_metadata",
-                "-1",
-                "-ac",
-                "1",
-                "-c:a",
-                "libopus",
-                "-b:a",
-                `${bitrateKbps}k`,
-                "-application",
-                "voip",
-                "-f",
-                "ogg",
-                "pipe:1",
-            ],
-            { stdio: ["pipe", "pipe", "pipe"] },
-        );
-
-        const stdoutChunks: Buffer[] = [];
-        const stderrChunks: Buffer[] = [];
-        let settled = false;
-
-        const settleReject = (err: Error) => {
-            if (settled) return;
-            settled = true;
-            reject(err);
-        };
-
-        ff.stdout.on("data", (c: Buffer) => stdoutChunks.push(c));
-        ff.stderr.on("data", (c: Buffer) => stderrChunks.push(c));
-
-        ff.on("error", (err) => {
-            settleReject(
-                new Error(
-                    `ffmpeg spawn failed (binary missing from runtime image?): ${err.message}`,
-                ),
-            );
-        });
-
-        ff.on("close", (code) => {
-            if (settled) return;
-            if (code !== 0) {
-                const stderr = Buffer.concat(stderrChunks).toString("utf8");
-                settleReject(
-                    new Error(
-                        `ffmpeg exited with code ${code}: ${stderr.trim() || "(no stderr)"}`,
-                    ),
-                );
-                return;
-            }
-            settled = true;
-            resolve(Buffer.concat(stdoutChunks));
-        });
-
-        ff.stdin.on("error", (err) => {
-            settleReject(
-                new Error(`ffmpeg stdin write failed: ${err.message}`),
-            );
-        });
-
-        ff.stdin.end(input);
-    });
 }

--- a/src/lib/transcription/ffmpeg.ts
+++ b/src/lib/transcription/ffmpeg.ts
@@ -1,0 +1,108 @@
+import { spawn } from "node:child_process";
+
+export function runFfmpeg(
+    input: Buffer,
+    args: readonly string[],
+): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const ff = spawn("ffmpeg", [...args], {
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+
+        const stdoutChunks: Buffer[] = [];
+        const stderrChunks: Buffer[] = [];
+        let settled = false;
+
+        const settleReject = (err: Error) => {
+            if (settled) return;
+            settled = true;
+            reject(err);
+        };
+
+        ff.stdout.on("data", (c: Buffer) => stdoutChunks.push(c));
+        ff.stderr.on("data", (c: Buffer) => stderrChunks.push(c));
+
+        ff.on("error", (err) => {
+            settleReject(
+                new Error(
+                    `ffmpeg spawn failed (binary missing from runtime image?): ${err.message}`,
+                ),
+            );
+        });
+
+        ff.on("close", (code) => {
+            if (settled) return;
+            if (code !== 0) {
+                const stderr = Buffer.concat(stderrChunks).toString("utf8");
+                settleReject(
+                    new Error(
+                        `ffmpeg exited with code ${code}: ${stderr.trim() || "(no stderr)"}`,
+                    ),
+                );
+                return;
+            }
+            settled = true;
+            resolve(Buffer.concat(stdoutChunks));
+        });
+
+        ff.stdin.on("error", (err) => {
+            settleReject(
+                new Error(`ffmpeg stdin write failed: ${err.message}`),
+            );
+        });
+
+        ff.stdin.end(input);
+    });
+}
+
+export function ffmpegToOpus(
+    input: Buffer,
+    bitrateKbps: number,
+): Promise<Buffer> {
+    return runFfmpeg(input, [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        "pipe:0",
+        "-vn",
+        "-map_metadata",
+        "-1",
+        "-ac",
+        "1",
+        "-c:a",
+        "libopus",
+        "-b:a",
+        `${bitrateKbps}k`,
+        "-application",
+        "voip",
+        "-f",
+        "ogg",
+        "pipe:1",
+    ]);
+}
+
+/** Mono 16 kHz MP3 for chat-style providers that reject Ogg/Opus. */
+export function transcodeToMp3(input: Buffer): Promise<Buffer> {
+    return runFfmpeg(input, [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        "pipe:0",
+        "-vn",
+        "-map_metadata",
+        "-1",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-c:a",
+        "libmp3lame",
+        "-b:a",
+        "64k",
+        "-f",
+        "mp3",
+        "pipe:1",
+    ]);
+}

--- a/src/tests/audio/sniff.test.ts
+++ b/src/tests/audio/sniff.test.ts
@@ -36,6 +36,23 @@ describe("sniffAudio", () => {
         expect(sniffed.extension).toBe("mp3");
     });
 
+    it("detects MP3 from an MPEG-1 Layer III frame sync", () => {
+        const sniffed = sniffAudio(Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+        expect(sniffed.container).toBe("mp3");
+        expect(sniffed.contentType).toBe("audio/mpeg");
+    });
+
+    it("does not classify ADTS AAC (0xFFF1 / 0xFFF9) as MP3", () => {
+        const f1 = sniffAudio(Buffer.from([0xff, 0xf1, 0x50, 0x80]));
+        expect(f1.container).toBe("aac");
+        expect(f1.contentType).toBe("audio/aac");
+        expect(f1.extension).toBe("aac");
+
+        const f9 = sniffAudio(Buffer.from([0xff, 0xf9, 0x50, 0x80]));
+        expect(f9.container).toBe("aac");
+        expect(f9.contentType).toBe("audio/aac");
+    });
+
     it("falls back to mp3/mpeg for unknown bytes (legacy Plaud default)", () => {
         const sniffed = sniffAudio(Buffer.from("not-audio"));
         expect(sniffed.container).toBe("unknown");

--- a/src/tests/audio/sniff.test.ts
+++ b/src/tests/audio/sniff.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isOggContainer, sniffAudio } from "@/lib/audio/sniff";
+
+function oggOpusBytes(): Buffer {
+    const buf = Buffer.alloc(48, 0);
+    buf.write("OggS", 0);
+    buf.write("OpusHead", 28);
+    return buf;
+}
+
+describe("sniffAudio", () => {
+    it("detects Ogg/Opus regardless of any filename", () => {
+        const sniffed = sniffAudio(oggOpusBytes());
+        expect(isOggContainer(oggOpusBytes())).toBe(true);
+        expect(sniffed.container).toBe("ogg");
+        expect(sniffed.codec).toBe("opus");
+        expect(sniffed.extension).toBe("ogg");
+        expect(sniffed.contentType).toBe("audio/ogg");
+    });
+
+    it("detects WAV from RIFF/WAVE", () => {
+        const buf = Buffer.alloc(12, 0);
+        buf.write("RIFF", 0);
+        buf.write("WAVE", 8);
+        const sniffed = sniffAudio(buf);
+        expect(sniffed.container).toBe("wav");
+        expect(sniffed.contentType).toBe("audio/wav");
+        expect(sniffed.extension).toBe("wav");
+    });
+
+    it("detects MP3 from an ID3 header", () => {
+        const buf = Buffer.from([0x49, 0x44, 0x33, 0x04, 0x00, 0x00]);
+        const sniffed = sniffAudio(buf);
+        expect(sniffed.container).toBe("mp3");
+        expect(sniffed.contentType).toBe("audio/mpeg");
+        expect(sniffed.extension).toBe("mp3");
+    });
+
+    it("falls back to mp3/mpeg for unknown bytes (legacy Plaud default)", () => {
+        const sniffed = sniffAudio(Buffer.from("not-audio"));
+        expect(sniffed.container).toBe("unknown");
+        expect(sniffed.extension).toBe("mp3");
+        expect(sniffed.contentType).toBe("audio/mpeg");
+    });
+});

--- a/src/tests/regressions/122-openrouter-transcription.test.ts
+++ b/src/tests/regressions/122-openrouter-transcription.test.ts
@@ -93,17 +93,31 @@ vi.mock("@/lib/plaud/client-factory", () => ({
 
 import { OpenAI } from "openai";
 import { db } from "@/db";
+import { createUserStorageProvider } from "@/lib/storage/factory";
 import { transcodeToMp3 } from "@/lib/transcription/ffmpeg";
 import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
+
+function oggOpusBytes(): Buffer {
+    const buf = Buffer.alloc(48, 0);
+    buf.write("OggS", 0);
+    buf.write("OpusHead", 28);
+    return buf;
+}
 
 describe("issue #122 — OpenRouter transcription uses chat-completions", () => {
     const userId = "user-122";
     const recordingId = "rec-122";
 
-    beforeEach(() => {
+    beforeEach(async () => {
         vi.clearAllMocks();
         audioCreate.mockReset();
         chatCreate.mockReset();
+        const storage = (await createUserStorageProvider(
+            userId,
+        )) as unknown as {
+            downloadFile: Mock;
+        };
+        storage.downloadFile.mockResolvedValue(Buffer.from("fake-mp3-bytes"));
         // biome-ignore lint/complexity/useArrowFunction: mock must be constructable
         (OpenAI as unknown as Mock).mockImplementation(function () {
             return {
@@ -240,7 +254,15 @@ describe("issue #122 — OpenRouter transcription uses chat-completions", () => 
         expect(audioPart?.input_audio?.data.length).toBeGreaterThan(0);
     });
 
-    it("transcodes opus/ogg to mp3 before chat.completions (OpenRouter cannot accept ogg)", async () => {
+    it("transcodes a .mp3 whose bytes are Ogg/Opus before chat.completions", async () => {
+        const ogg = oggOpusBytes();
+        const storage = (await createUserStorageProvider(
+            userId,
+        )) as unknown as {
+            downloadFile: Mock;
+        };
+        storage.downloadFile.mockResolvedValue(ogg);
+
         chatCreate.mockResolvedValue({
             choices: [{ message: { content: "opus became mp3" } }],
         });
@@ -254,8 +276,8 @@ describe("issue #122 — OpenRouter transcription uses chat-completions", () => 
                                 id: recordingId,
                                 userId,
                                 plaudFileId: "plaud-1",
-                                filename: "Opus upload",
-                                storagePath: "rec-122.opus",
+                                filename: "2026-05-19 18-06-54.mp3",
+                                storagePath: "rec-122.mp3",
                                 deletedAt: null,
                             },
                         ]),
@@ -337,6 +359,7 @@ describe("issue #122 — OpenRouter transcription uses chat-completions", () => 
         expect(result.success).toBe(true);
         expect(result.text).toBe("opus became mp3");
         expect(transcodeToMp3).toHaveBeenCalledTimes(1);
+        expect(transcodeToMp3).toHaveBeenCalledWith(ogg);
         expect(audioCreate).not.toHaveBeenCalled();
         expect(chatCreate).toHaveBeenCalledTimes(1);
         const contentParts = chatCreate.mock.calls[0]?.[0]?.messages?.[0]

--- a/src/tests/regressions/122-openrouter-transcription.test.ts
+++ b/src/tests/regressions/122-openrouter-transcription.test.ts
@@ -77,6 +77,12 @@ vi.mock("@/lib/hosted/transcription/mynah", () => ({
     transcribeViaMynah: vi.fn(),
 }));
 
+vi.mock("@/lib/transcription/ffmpeg", () => ({
+    transcodeToMp3: vi.fn().mockResolvedValue(Buffer.from("transcoded-mp3")),
+    ffmpegToOpus: vi.fn(),
+    runFfmpeg: vi.fn(),
+}));
+
 vi.mock("@/lib/ai/generate-title", () => ({
     generateTitleFromTranscription: vi.fn().mockResolvedValue(null),
 }));
@@ -87,6 +93,7 @@ vi.mock("@/lib/plaud/client-factory", () => ({
 
 import { OpenAI } from "openai";
 import { db } from "@/db";
+import { transcodeToMp3 } from "@/lib/transcription/ffmpeg";
 import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
 
 describe("issue #122 — OpenRouter transcription uses chat-completions", () => {
@@ -233,7 +240,11 @@ describe("issue #122 — OpenRouter transcription uses chat-completions", () => 
         expect(audioPart?.input_audio?.data.length).toBeGreaterThan(0);
     });
 
-    it("returns an actionable error when the audio is opus (chat-style providers can't accept it)", async () => {
+    it("transcodes opus/ogg to mp3 before chat.completions (OpenRouter cannot accept ogg)", async () => {
+        chatCreate.mockResolvedValue({
+            choices: [{ message: { content: "opus became mp3" } }],
+        });
+
         (db.select as Mock)
             .mockReturnValueOnce({
                 from: vi.fn().mockReturnValue({
@@ -287,10 +298,53 @@ describe("issue #122 — OpenRouter transcription uses chat-completions", () => 
                 }),
             });
 
+        const tx = {
+            select: vi
+                .fn()
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            for: vi.fn().mockReturnValue({
+                                limit: vi
+                                    .fn()
+                                    .mockResolvedValue([{ deletedAt: null }]),
+                            }),
+                        }),
+                    }),
+                })
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi.fn().mockResolvedValue([]),
+                        }),
+                    }),
+                }),
+            insert: vi.fn().mockReturnValue({
+                values: vi.fn().mockResolvedValue(undefined),
+            }),
+            update: vi.fn().mockReturnValue({
+                set: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue(undefined),
+                }),
+            }),
+        };
+        (db.transaction as Mock).mockImplementation(
+            async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx),
+        );
+
         const result = await transcribeRecording(userId, recordingId);
 
-        expect(result.success).toBe(false);
-        expect(result.error).toMatch(/mp3|wav/i);
-        expect(chatCreate).not.toHaveBeenCalled();
+        expect(result.success).toBe(true);
+        expect(result.text).toBe("opus became mp3");
+        expect(transcodeToMp3).toHaveBeenCalledTimes(1);
+        expect(audioCreate).not.toHaveBeenCalled();
+        expect(chatCreate).toHaveBeenCalledTimes(1);
+        const contentParts = chatCreate.mock.calls[0]?.[0]?.messages?.[0]
+            ?.content as Array<{
+            type: string;
+            input_audio?: { format: string };
+        }>;
+        const audioPart = contentParts.find((p) => p.type === "input_audio");
+        expect(audioPart?.input_audio?.format).toBe("mp3");
     });
 });

--- a/src/tests/regressions/160-plaud-ogg-opus.test.ts
+++ b/src/tests/regressions/160-plaud-ogg-opus.test.ts
@@ -202,7 +202,7 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
             expect(result.errors).toEqual([]);
             expect(storage.uploadFile).toHaveBeenCalledTimes(1);
             const [key, body, contentType] = storage.uploadFile.mock.calls[0];
-            expect(key).toMatch(/\.ogg$/);
+            expect(key).toBe("user-160/plaud-160.ogg");
             expect(body).toBe(oggBuffer);
             expect(contentType).toBe("audio/ogg");
             expect(storage.deleteFile).not.toHaveBeenCalled();

--- a/src/tests/regressions/160-plaud-ogg-opus.test.ts
+++ b/src/tests/regressions/160-plaud-ogg-opus.test.ts
@@ -209,6 +209,7 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
         });
 
         function stubUpdateTransaction() {
+            const setPayloads: Array<{ storagePath?: string }> = [];
             (db.transaction as Mock).mockImplementation(
                 async (cb: (tx: unknown) => Promise<boolean>) => {
                     const tx = {
@@ -226,9 +227,18 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
                             }),
                         }),
                         update: vi.fn().mockReturnValue({
-                            set: vi.fn().mockReturnValue({
-                                where: vi.fn().mockResolvedValue(undefined),
-                            }),
+                            set: vi
+                                .fn()
+                                .mockImplementation(
+                                    (payload: { storagePath?: string }) => {
+                                        setPayloads.push(payload);
+                                        return {
+                                            where: vi
+                                                .fn()
+                                                .mockResolvedValue(undefined),
+                                        };
+                                    },
+                                ),
                         }),
                     };
                     return cb(tx);
@@ -239,6 +249,7 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
                     where: vi.fn().mockResolvedValue(undefined),
                 }),
             });
+            return { setPayloads };
         }
 
         it("re-syncs Ogg/Opus onto the existing key with an honest MIME", async () => {
@@ -260,7 +271,7 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
                 ],
                 [],
             ]);
-            stubUpdateTransaction();
+            const { setPayloads } = stubUpdateTransaction();
 
             const result = await syncRecordingsForUser(mockUserId);
 
@@ -271,6 +282,7 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
                 oggBuffer,
                 "audio/ogg",
             );
+            expect(setPayloads[0]?.storagePath).toBe(oldPath);
             expect(storage.deleteFile).not.toHaveBeenCalled();
         });
 
@@ -294,7 +306,7 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
                 [{ id: "other-rec" }],
                 [],
             ]);
-            stubUpdateTransaction();
+            const { setPayloads } = stubUpdateTransaction();
 
             const result = await syncRecordingsForUser(mockUserId);
 
@@ -302,10 +314,11 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
             expect(result.errors).toEqual([]);
             expect(storage.uploadFile).toHaveBeenCalledTimes(1);
             const [key, body, contentType] = storage.uploadFile.mock.calls[0];
+            expect(key).toBe("user-160/plaud-160.ogg");
             expect(key).not.toBe(sharedPath);
-            expect(key).toMatch(/\.ogg$/);
             expect(body).toBe(oggBuffer);
             expect(contentType).toBe("audio/ogg");
+            expect(setPayloads[0]?.storagePath).toBe(key);
             expect(storage.deleteFile).not.toHaveBeenCalled();
         });
     });

--- a/src/tests/regressions/160-plaud-ogg-opus.test.ts
+++ b/src/tests/regressions/160-plaud-ogg-opus.test.ts
@@ -208,25 +208,7 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
             expect(storage.deleteFile).not.toHaveBeenCalled();
         });
 
-        it("re-syncs Ogg/Opus onto the existing key with an honest MIME", async () => {
-            const oldPath = "user-160/2026-05-19 18-06-54.mp3.mp3";
-            const storage = await storageMock();
-            stubPlaud();
-            stubSelects([
-                [{ id: "conn-1", userId: mockUserId, bearerToken: "tok" }],
-                [{ id: "settings-1" }],
-                [{ email: "t@example.com" }],
-                [
-                    {
-                        id: "local-rec-160",
-                        plaudFileId: "plaud-160",
-                        plaudVersion: "1",
-                        storagePath: oldPath,
-                        deletedAt: null,
-                    },
-                ],
-            ]);
-
+        function stubUpdateTransaction() {
             (db.transaction as Mock).mockImplementation(
                 async (cb: (tx: unknown) => Promise<boolean>) => {
                     const tx = {
@@ -257,6 +239,28 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
                     where: vi.fn().mockResolvedValue(undefined),
                 }),
             });
+        }
+
+        it("re-syncs Ogg/Opus onto the existing key with an honest MIME", async () => {
+            const oldPath = "user-160/2026-05-19 18-06-54.mp3.mp3";
+            const storage = await storageMock();
+            stubPlaud();
+            stubSelects([
+                [{ id: "conn-1", userId: mockUserId, bearerToken: "tok" }],
+                [{ id: "settings-1" }],
+                [{ email: "t@example.com" }],
+                [
+                    {
+                        id: "local-rec-160",
+                        plaudFileId: "plaud-160",
+                        plaudVersion: "1",
+                        storagePath: oldPath,
+                        deletedAt: null,
+                    },
+                ],
+                [],
+            ]);
+            stubUpdateTransaction();
 
             const result = await syncRecordingsForUser(mockUserId);
 
@@ -267,6 +271,41 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
                 oggBuffer,
                 "audio/ogg",
             );
+            expect(storage.deleteFile).not.toHaveBeenCalled();
+        });
+
+        it("allocates a new key when another row still shares storagePath", async () => {
+            const sharedPath = "user-160/2026-05-19 18-06-54.mp3.mp3";
+            const storage = await storageMock();
+            stubPlaud();
+            stubSelects([
+                [{ id: "conn-1", userId: mockUserId, bearerToken: "tok" }],
+                [{ id: "settings-1" }],
+                [{ email: "t@example.com" }],
+                [
+                    {
+                        id: "local-rec-160",
+                        plaudFileId: "plaud-160",
+                        plaudVersion: "1",
+                        storagePath: sharedPath,
+                        deletedAt: null,
+                    },
+                ],
+                [{ id: "other-rec" }],
+                [],
+            ]);
+            stubUpdateTransaction();
+
+            const result = await syncRecordingsForUser(mockUserId);
+
+            expect(result.updatedRecordings).toBe(1);
+            expect(result.errors).toEqual([]);
+            expect(storage.uploadFile).toHaveBeenCalledTimes(1);
+            const [key, body, contentType] = storage.uploadFile.mock.calls[0];
+            expect(key).not.toBe(sharedPath);
+            expect(key).toMatch(/\.ogg$/);
+            expect(body).toBe(oggBuffer);
+            expect(contentType).toBe("audio/ogg");
             expect(storage.deleteFile).not.toHaveBeenCalled();
         });
     });

--- a/src/tests/regressions/160-plaud-ogg-opus.test.ts
+++ b/src/tests/regressions/160-plaud-ogg-opus.test.ts
@@ -38,6 +38,14 @@ vi.mock("@/lib/entitlements", () => ({
     isHostedLockedOut: vi.fn().mockResolvedValue(false),
 }));
 
+vi.mock("@/lib/hosted/billing/storage-cap", () => ({
+    enforceStorageCap: vi.fn().mockResolvedValue({
+        allowed: true,
+        currentBytes: 0,
+        limitBytes: null,
+    }),
+}));
+
 vi.mock("@/lib/plaud/client-factory", () => ({
     createPlaudClient: vi.fn(),
 }));
@@ -132,43 +140,29 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
             vi.clearAllMocks();
         });
 
-        async function runOggUpdate(args: {
-            oldPath: string;
-            otherHolders: unknown[];
-        }) {
-            const storageMock = (await createUserStorageProvider(
+        async function storageMock() {
+            const storage = (await createUserStorageProvider(
                 mockUserId,
             )) as unknown as {
                 uploadFile: Mock;
                 deleteFile: Mock;
             };
-            storageMock.uploadFile.mockClear();
-            storageMock.deleteFile.mockClear();
+            storage.uploadFile.mockClear();
+            storage.deleteFile.mockClear();
+            return storage;
+        }
 
+        function stubPlaud() {
             (createPlaudClient as Mock).mockResolvedValue({
                 getRecordings: vi.fn().mockResolvedValue({
                     data_file_list: [mockPlaudRecording],
                 }),
                 downloadRecording: vi.fn().mockResolvedValue(oggBuffer),
             });
+        }
 
+        function stubSelects(results: unknown[][]) {
             const chain = (db.select as Mock).mockReset();
-            const results: unknown[][] = [
-                [{ id: "conn-1", userId: mockUserId, bearerToken: "tok" }],
-                [{ id: "settings-1" }],
-                [{ email: "t@example.com" }],
-                [
-                    {
-                        id: "local-rec-160",
-                        plaudFileId: "plaud-160",
-                        plaudVersion: "1",
-                        storagePath: args.oldPath,
-                        deletedAt: null,
-                    },
-                ],
-                [],
-                args.otherHolders,
-            ];
             for (const result of results) {
                 chain.mockReturnValueOnce({
                     from: vi.fn().mockReturnValue({
@@ -178,6 +172,60 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
                     }),
                 });
             }
+        }
+
+        it("stores a new Plaud Ogg/Opus download as audio/ogg with a .ogg key", async () => {
+            const storage = await storageMock();
+            stubPlaud();
+            stubSelects([
+                [{ id: "conn-1", userId: mockUserId, bearerToken: "tok" }],
+                [{ id: "settings-1" }],
+                [{ email: "t@example.com" }],
+                [],
+                [],
+            ]);
+
+            (db.insert as Mock).mockReturnValue({
+                values: vi.fn().mockReturnValue({
+                    returning: vi.fn().mockResolvedValue([{ id: "new-rec" }]),
+                }),
+            });
+            (db.update as Mock).mockReturnValue({
+                set: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue(undefined),
+                }),
+            });
+
+            const result = await syncRecordingsForUser(mockUserId);
+
+            expect(result.newRecordings).toBe(1);
+            expect(result.errors).toEqual([]);
+            expect(storage.uploadFile).toHaveBeenCalledTimes(1);
+            const [key, body, contentType] = storage.uploadFile.mock.calls[0];
+            expect(key).toMatch(/\.ogg$/);
+            expect(body).toBe(oggBuffer);
+            expect(contentType).toBe("audio/ogg");
+            expect(storage.deleteFile).not.toHaveBeenCalled();
+        });
+
+        it("re-syncs Ogg/Opus onto the existing key with an honest MIME", async () => {
+            const oldPath = "user-160/2026-05-19 18-06-54.mp3.mp3";
+            const storage = await storageMock();
+            stubPlaud();
+            stubSelects([
+                [{ id: "conn-1", userId: mockUserId, bearerToken: "tok" }],
+                [{ id: "settings-1" }],
+                [{ email: "t@example.com" }],
+                [
+                    {
+                        id: "local-rec-160",
+                        plaudFileId: "plaud-160",
+                        plaudVersion: "1",
+                        storagePath: oldPath,
+                        deletedAt: null,
+                    },
+                ],
+            ]);
 
             (db.transaction as Mock).mockImplementation(
                 async (cb: (tx: unknown) => Promise<boolean>) => {
@@ -204,7 +252,6 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
                     return cb(tx);
                 },
             );
-
             (db.update as Mock).mockReturnValue({
                 set: vi.fn().mockReturnValue({
                     where: vi.fn().mockResolvedValue(undefined),
@@ -212,38 +259,15 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
             });
 
             const result = await syncRecordingsForUser(mockUserId);
-            return { result, storageMock };
-        }
-
-        it("uploads Ogg/Opus bytes as audio/ogg with a .ogg key", async () => {
-            const oldPath = "user-160/2026-05-19 18-06-54.mp3.mp3";
-            const { result, storageMock } = await runOggUpdate({
-                oldPath,
-                otherHolders: [],
-            });
 
             expect(result.updatedRecordings).toBe(1);
             expect(result.errors).toEqual([]);
-            expect(storageMock.uploadFile).toHaveBeenCalledTimes(1);
-            const [key, body, contentType] =
-                storageMock.uploadFile.mock.calls[0];
-            expect(key).toMatch(/\.ogg$/);
-            expect(body).toBe(oggBuffer);
-            expect(contentType).toBe("audio/ogg");
-            expect(sniffAudio(body as Buffer).codec).toBe("opus");
-            expect(storageMock.deleteFile).toHaveBeenCalledWith(oldPath);
-        });
-
-        it("does not delete a replaced path still referenced by another recording", async () => {
-            const oldPath = "user-160/shared.mp3.mp3";
-            const { result, storageMock } = await runOggUpdate({
+            expect(storage.uploadFile).toHaveBeenCalledWith(
                 oldPath,
-                otherHolders: [{ id: "local-rec-other" }],
-            });
-
-            expect(result.updatedRecordings).toBe(1);
-            expect(storageMock.uploadFile).toHaveBeenCalledTimes(1);
-            expect(storageMock.deleteFile).not.toHaveBeenCalled();
+                oggBuffer,
+                "audio/ogg",
+            );
+            expect(storage.deleteFile).not.toHaveBeenCalled();
         });
     });
 

--- a/src/tests/regressions/160-plaud-ogg-opus.test.ts
+++ b/src/tests/regressions/160-plaud-ogg-opus.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Regression: issue #160
+ *
+ * Plaud labels downloads `.mp3` and Riffado used to store them as
+ * `audio/mpeg`, but the bytes are Ogg/Opus (`OggS`, vendor PALUD.AI).
+ * OpenRouter chat-style transcription then rejected `audio/ogg`.
+ *
+ * After the fix:
+ *   1. Container/codec come from magic bytes, not the filename.
+ *   2. Sync stores the sniffed extension + MIME.
+ *   3. Chat providers transcode unsupported audio to mp3 via the same
+ *      ffmpeg binary already used for Whisper size compression.
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        DEFAULT_STORAGE_TYPE: "local",
+        ENCRYPTION_KEY:
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    },
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        transaction: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/entitlements", () => ({
+    isHostedLockedOut: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("@/lib/plaud/client-factory", () => ({
+    createPlaudClient: vi.fn(),
+}));
+
+vi.mock("@/lib/storage/factory", () => ({
+    createUserStorageProvider: vi.fn().mockResolvedValue({
+        uploadFile: vi.fn().mockResolvedValue(undefined),
+        downloadFile: vi.fn().mockResolvedValue(Buffer.from("audio-data")),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+    }),
+}));
+
+vi.mock("@/lib/notifications/bark", () => ({
+    sendNewRecordingBarkNotification: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/lib/notifications/email", () => ({
+    sendNewRecordingEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/transcription/transcribe-recording", () => ({
+    transcribeRecording: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/posthog-server", () => ({
+    captureServerEvent: vi.fn(),
+    captureServerException: vi.fn(),
+}));
+
+import { db } from "@/db";
+import { sniffAudio } from "@/lib/audio/sniff";
+import { createPlaudClient } from "@/lib/plaud/client-factory";
+import { createUserStorageProvider } from "@/lib/storage/factory";
+import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
+import { buildAudioFile } from "@/lib/transcription/audio-file";
+import { chatTranscribe } from "@/lib/transcription/chat-transcribe";
+import { ffmpegToOpus, transcodeToMp3 } from "@/lib/transcription/ffmpeg";
+
+const FIXTURE = path.join(__dirname, "..", "fixtures", "sample.mp3");
+
+function hasFfmpeg(): boolean {
+    const probe = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" });
+    return probe.status === 0;
+}
+
+function oggOpusBytes(): Buffer {
+    const buf = Buffer.alloc(48, 0);
+    buf.write("OggS", 0);
+    buf.write("OpusHead", 28);
+    return buf;
+}
+
+const itIfFfmpeg = hasFfmpeg() ? it : it.skip;
+
+describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
+    it("buildAudioFile sniffs Ogg bytes even when the path is .mp3", () => {
+        const { file, contentType } = buildAudioFile(
+            oggOpusBytes(),
+            "user-1/2026-05-19 18-06-54.mp3",
+            "2026-05-19 18-06-54.mp3",
+        );
+        expect(contentType).toBe("audio/ogg");
+        expect(file.type).toBe("audio/ogg");
+        expect(file.name).toBe("2026-05-19 18-06-54.ogg");
+    });
+
+    describe("sync stores sniffed container, not the Plaud filename", () => {
+        const mockUserId = "user-160";
+        const oggBuffer = oggOpusBytes();
+
+        const mockPlaudRecording = {
+            id: "plaud-160",
+            filename: "2026-05-19 18-06-54.mp3",
+            duration: 6500,
+            start_time: "2026-05-19T18:06:54Z",
+            end_time: "2026-05-19T18:07:00Z",
+            filesize: oggBuffer.length,
+            file_md5: "oggmd5",
+            serial_number: "SN160",
+            version_ms: 9999,
+            timezone: 0,
+            zonemins: 0,
+            scene: 0,
+            is_trash: false,
+        };
+
+        beforeEach(() => {
+            vi.clearAllMocks();
+        });
+
+        it("uploads Ogg/Opus bytes as audio/ogg with a .ogg key", async () => {
+            const storageMock = (await createUserStorageProvider(
+                mockUserId,
+            )) as unknown as {
+                uploadFile: Mock;
+            };
+            storageMock.uploadFile.mockClear();
+
+            (createPlaudClient as Mock).mockResolvedValue({
+                getRecordings: vi.fn().mockResolvedValue({
+                    data_file_list: [mockPlaudRecording],
+                }),
+                downloadRecording: vi.fn().mockResolvedValue(oggBuffer),
+            });
+
+            const chain = (db.select as Mock).mockReset();
+            const results: unknown[][] = [
+                [{ id: "conn-1", userId: mockUserId, bearerToken: "tok" }],
+                [{ id: "settings-1" }],
+                [{ email: "t@example.com" }],
+                [
+                    {
+                        id: "local-rec-160",
+                        plaudFileId: "plaud-160",
+                        plaudVersion: "1",
+                        deletedAt: null,
+                    },
+                ],
+                [],
+            ];
+            for (const result of results) {
+                chain.mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi.fn().mockResolvedValue(result),
+                        }),
+                    }),
+                });
+            }
+
+            (db.transaction as Mock).mockImplementation(
+                async (cb: (tx: unknown) => Promise<boolean>) => {
+                    const tx = {
+                        select: vi.fn().mockReturnValue({
+                            from: vi.fn().mockReturnValue({
+                                where: vi.fn().mockReturnValue({
+                                    for: vi.fn().mockReturnValue({
+                                        limit: vi
+                                            .fn()
+                                            .mockResolvedValue([
+                                                { deletedAt: null },
+                                            ]),
+                                    }),
+                                }),
+                            }),
+                        }),
+                        update: vi.fn().mockReturnValue({
+                            set: vi.fn().mockReturnValue({
+                                where: vi.fn().mockResolvedValue(undefined),
+                            }),
+                        }),
+                    };
+                    return cb(tx);
+                },
+            );
+
+            (db.update as Mock).mockReturnValue({
+                set: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue(undefined),
+                }),
+            });
+
+            const result = await syncRecordingsForUser(mockUserId);
+
+            expect(result.updatedRecordings).toBe(1);
+            expect(result.errors).toEqual([]);
+            expect(storageMock.uploadFile).toHaveBeenCalledTimes(1);
+            const [key, body, contentType] =
+                storageMock.uploadFile.mock.calls[0];
+            expect(key).toMatch(/\.ogg$/);
+            expect(body).toBe(oggBuffer);
+            expect(contentType).toBe("audio/ogg");
+            expect(sniffAudio(body as Buffer).codec).toBe("opus");
+        });
+    });
+
+    itIfFfmpeg(
+        "transcodes Ogg/Opus to mp3 before OpenRouter chat.completions",
+        async () => {
+            const fixture = await readFile(FIXTURE);
+            const ogg = await ffmpegToOpus(fixture, 16);
+            expect(sniffAudio(ogg).container).toBe("ogg");
+
+            const chatCreate = vi.fn().mockResolvedValue({
+                choices: [{ message: { content: "hello from openrouter" } }],
+            });
+
+            const result = await chatTranscribe({
+                client: {
+                    chat: { completions: { create: chatCreate } },
+                } as never,
+                model: "google/gemini-2.5-flash-lite",
+                audioBuffer: ogg,
+                contentType: "audio/mpeg",
+                language: "en",
+            });
+
+            expect(result.text).toBe("hello from openrouter");
+            expect(chatCreate).toHaveBeenCalledTimes(1);
+            const contentParts = chatCreate.mock.calls[0]?.[0]?.messages?.[0]
+                ?.content as Array<{
+                type: string;
+                input_audio?: { format: string; data: string };
+            }>;
+            const audioPart = contentParts.find(
+                (p) => p.type === "input_audio",
+            );
+            expect(audioPart?.input_audio?.format).toBe("mp3");
+            const sent = Buffer.from(
+                audioPart?.input_audio?.data ?? "",
+                "base64",
+            );
+            expect(sniffAudio(sent).container).toBe("mp3");
+            expect(sent.equals(ogg)).toBe(false);
+        },
+        20_000,
+    );
+
+    itIfFfmpeg(
+        "transcodeToMp3 writes a real MPEG stream",
+        async () => {
+            const fixture = await readFile(FIXTURE);
+            const ogg = await ffmpegToOpus(fixture, 16);
+            const mp3 = await transcodeToMp3(ogg);
+            expect(sniffAudio(mp3).container).toBe("mp3");
+            expect(mp3.length).toBeGreaterThan(0);
+        },
+        15_000,
+    );
+});

--- a/src/tests/regressions/160-plaud-ogg-opus.test.ts
+++ b/src/tests/regressions/160-plaud-ogg-opus.test.ts
@@ -132,8 +132,10 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
             vi.clearAllMocks();
         });
 
-        it("uploads Ogg/Opus bytes as audio/ogg with a .ogg key", async () => {
-            const oldPath = "user-160/2026-05-19 18-06-54.mp3.mp3";
+        async function runOggUpdate(args: {
+            oldPath: string;
+            otherHolders: unknown[];
+        }) {
             const storageMock = (await createUserStorageProvider(
                 mockUserId,
             )) as unknown as {
@@ -160,11 +162,12 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
                         id: "local-rec-160",
                         plaudFileId: "plaud-160",
                         plaudVersion: "1",
-                        storagePath: oldPath,
+                        storagePath: args.oldPath,
                         deletedAt: null,
                     },
                 ],
                 [],
+                args.otherHolders,
             ];
             for (const result of results) {
                 chain.mockReturnValueOnce({
@@ -209,6 +212,15 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
             });
 
             const result = await syncRecordingsForUser(mockUserId);
+            return { result, storageMock };
+        }
+
+        it("uploads Ogg/Opus bytes as audio/ogg with a .ogg key", async () => {
+            const oldPath = "user-160/2026-05-19 18-06-54.mp3.mp3";
+            const { result, storageMock } = await runOggUpdate({
+                oldPath,
+                otherHolders: [],
+            });
 
             expect(result.updatedRecordings).toBe(1);
             expect(result.errors).toEqual([]);
@@ -220,6 +232,18 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
             expect(contentType).toBe("audio/ogg");
             expect(sniffAudio(body as Buffer).codec).toBe("opus");
             expect(storageMock.deleteFile).toHaveBeenCalledWith(oldPath);
+        });
+
+        it("does not delete a replaced path still referenced by another recording", async () => {
+            const oldPath = "user-160/shared.mp3.mp3";
+            const { result, storageMock } = await runOggUpdate({
+                oldPath,
+                otherHolders: [{ id: "local-rec-other" }],
+            });
+
+            expect(result.updatedRecordings).toBe(1);
+            expect(storageMock.uploadFile).toHaveBeenCalledTimes(1);
+            expect(storageMock.deleteFile).not.toHaveBeenCalled();
         });
     });
 

--- a/src/tests/regressions/160-plaud-ogg-opus.test.ts
+++ b/src/tests/regressions/160-plaud-ogg-opus.test.ts
@@ -133,12 +133,15 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
         });
 
         it("uploads Ogg/Opus bytes as audio/ogg with a .ogg key", async () => {
+            const oldPath = "user-160/2026-05-19 18-06-54.mp3.mp3";
             const storageMock = (await createUserStorageProvider(
                 mockUserId,
             )) as unknown as {
                 uploadFile: Mock;
+                deleteFile: Mock;
             };
             storageMock.uploadFile.mockClear();
+            storageMock.deleteFile.mockClear();
 
             (createPlaudClient as Mock).mockResolvedValue({
                 getRecordings: vi.fn().mockResolvedValue({
@@ -157,6 +160,7 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
                         id: "local-rec-160",
                         plaudFileId: "plaud-160",
                         plaudVersion: "1",
+                        storagePath: oldPath,
                         deletedAt: null,
                     },
                 ],
@@ -215,6 +219,7 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
             expect(body).toBe(oggBuffer);
             expect(contentType).toBe("audio/ogg");
             expect(sniffAudio(body as Buffer).codec).toBe("opus");
+            expect(storageMock.deleteFile).toHaveBeenCalledWith(oldPath);
         });
     });
 

--- a/src/tests/regressions/160-plaud-ogg-opus.test.ts
+++ b/src/tests/regressions/160-plaud-ogg-opus.test.ts
@@ -208,6 +208,35 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
             expect(storage.deleteFile).not.toHaveBeenCalled();
         });
 
+        it("fails closed when every candidate storage key is already held", async () => {
+            const storage = await storageMock();
+            stubPlaud();
+            stubSelects([
+                [{ id: "conn-1", userId: mockUserId, bearerToken: "tok" }],
+                [{ id: "settings-1" }],
+                [{ email: "t@example.com" }],
+                [],
+            ]);
+            (db.select as Mock).mockReturnValue({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([{ id: "taken" }]),
+                    }),
+                }),
+            });
+            (db.update as Mock).mockReturnValue({
+                set: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue(undefined),
+                }),
+            });
+
+            const result = await syncRecordingsForUser(mockUserId);
+
+            expect(result.newRecordings).toBe(0);
+            expect(result.errors.length).toBeGreaterThan(0);
+            expect(storage.uploadFile).not.toHaveBeenCalled();
+        });
+
         function stubUpdateTransaction() {
             const setPayloads: Array<{ storagePath?: string }> = [];
             (db.transaction as Mock).mockImplementation(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Plaud-synced files named `.mp3` are often Ogg/Opus (`OggS`, vendor `PALUD.AI`). Sync used to store them as `audio/mpeg`, then OpenRouter chat transcription rejected `audio/ogg`.

This PR sniffs the real container/codec from magic bytes and transcodes unsupported audio to mp3 for chat-style providers, using the ffmpeg binary already in the runtime image (same one Whisper size-compression uses). No new conversion library.

Rebased onto `main` after #279 and #280. Chat transcription keeps this PR's sniff + transcode path and #280's `WHISPER_REQUEST_TIMEOUT_MS` on `chat.completions.create`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #160

## Changes Made

- `sniffAudio()` detects container/codec from bytes (Ogg/Opus, WAV, MP3, ADTS AAC, etc.), ignoring filename.
- New Plaud syncs store the sniffed extension and MIME (`audio/ogg` + `.ogg`) instead of hardcoding `.mp3` / `audio/mpeg`.
- New and shared-path storage keys are `userId/{plaudFileId}.ext`, unique per Plaud file across processes. Sole-owner re-syncs still overwrite the existing key in place.
- Allocation fails closed if 100 candidate keys are all occupied, instead of overwriting a taken object.
- `buildAudioFile()` uses the sniff so a Plaud `.mp3` that is actually Ogg is labeled `audio/ogg`.
- `chatTranscribe()` transcodes non-mp3/wav (including lying `audio/mpeg` + Ogg bytes) to 16 kHz mono mp3 before `input_audio`, and passes `{ timeout: env.WHISPER_REQUEST_TIMEOUT_MS }` to `chat.completions.create`.
- Shared `runFfmpeg` helper; Whisper compression now calls the same spawn path.
- Format error only if ffmpeg is missing or the encode fails.

Existing recordings that were stored as `.mp3` with Ogg bytes still transcribe: the chat path sniffs the buffer, not the stored name.

Whisper and Gemini keep the original Ogg/Opus (they already accept it).

## Testing

- `pnpm format-and-lint:fix` (pre-existing infos in `elevated-cookie.test.ts` only)
- `pnpm type-check`
- `pnpm test` — 905 passed, 10 skipped (includes #279/#280 tests now on main)

### Test Steps
1. Sync a new Plaud recording whose download is Ogg/Opus labeled `.mp3`.
2. Confirm storage key/MIME are `userId/{plaudFileId}.ogg` / `audio/ogg`.
3. Transcribe with OpenRouter (chat-style). Should succeed; request `input_audio.format` is `mp3`.
4. Re-transcribe an already-synced mislabeled `.mp3` (Ogg bytes). Should also succeed.
5. Re-sync a sole-owner recording: same key is overwritten as `audio/ogg`; the row stays on that path.
6. Re-sync a recording whose `storagePath` is also held by another row: upload and `storagePath` both move to `userId/{plaudFileId}.ogg`; the shared object is not deleted.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)
- [x] Type checking passes (`pnpm type-check`)

## Database Changes

- [ ] I have generated a new migration (`pnpm db:generate`)

## Additional Notes

ffmpeg is already installed in the Docker image for Whisper 25 MiB compression. This change adds an mp3 encode path (`libmp3lame`) on that same binary. Self-host `pnpm dev` without ffmpeg still fails the chat path with an explicit conversion error instead of a silent format lie.

No schema or env changes. Did not convert audio at sync time (keeps original Opus for Whisper/Gemini).

## For Reviewers

- Sync honesty vs transcode-at-chat-time: transcode is only for providers that reject Ogg.
- Allocated keys include `plaudFileId`, so two processes cannot pick the same key for different recordings. The HTTP rate limit is a token bucket (not exclusion) and background sync skips it; an in-memory reservation cannot be the uniqueness mechanism.
- Sole-owner re-syncs keep the existing key. Shared-path re-syncs allocate `userId/{plaudFileId}.ext` and never delete the old object.
- If every candidate key is taken, sync of that recording fails instead of clobbering another blob.
- Already-stored lying `.mp3` blobs transcribe via byte sniff without a rewrite.
- `#122` keeps #280 timeout assertions and this PR's Ogg-under-`.mp3` transcode coverage. The old "opus must fail" case is gone on purpose.
- MPEG frame sniff requires a non-zero layer so ADTS AAC (`0xFFF1` / `0xFFF9`) is not stored as `audio/mpeg`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2b53567-5508-4982-9f28-cbabca9f044f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2b53567-5508-4982-9f28-cbabca9f044f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat transcription failures for Plaud Ogg/Opus files mislabeled as .mp3 by sniffing bytes to store the real type and transcoding to mp3 only for chat-style providers like OpenRouter. Previously we saved audio/mpeg under .mp3 and chat transcription rejected Ogg bytes; now we store audio/ogg and convert on request so both new and existing mislabeled blobs transcribe.

**Bug Fixes**
- New and replacement storage keys are `userId/<plaudFileId>.<ext>` from the sniffed MIME; filenames no longer drive keys or formats.
- Re-sync overwrites in place when this row is the sole holder; if another row shares the key, allocate `userId/<plaudFileId>.ogg` and keep the shared object.
- When a re-sync changes the container and the old key is unshared, delete the replaced blob.
- Storage-key allocation is serialized; if all candidates are occupied, sync fails instead of overwriting another blob.
- Chat transcription transcodes unsupported audio to 16 kHz mono mp3 and raises a clear error if `ffmpeg` is missing or the encode fails.
- Stops misclassifying ADTS AAC as MP3; mislabeled Ogg/Opus now transcribe, while Whisper/Gemini keep Ogg/Opus.

**Refactors**
- Adds a shared `ffmpeg` runner (`transcodeToMp3`, `ffmpegToOpus`) reused by Whisper compression.

<sup>Written for commit 67cc4afb05e9bb4a94661541ab690a5ae371777f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

