### PR TITLE
fix(self-host): persist storage, pass SMTP, retry auto-transcribe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,10 +99,10 @@ ENCRYPTION_KEY=your-64-char-hex-encryption-key-here
 # Storage Configuration
 DEFAULT_STORAGE_TYPE=local
 
-# Local storage path. The bundled docker-compose.yml mounts the `audio` named
-# volume at /app/audio and now forwards LOCAL_STORAGE_PATH into the container
-# with that default, so leave this unset (or set to /app/audio) for Docker.
-# For local dev outside Docker, use ./storage.
+# Local storage path. The bundled docker-compose.yml mounts named volumes at
+# /app/audio and /app/storage, and forwards LOCAL_STORAGE_PATH with default
+# /app/audio. Leave this unset (or set to /app/audio) for Docker. For local
+# dev outside Docker, use ./storage.
 # LOCAL_STORAGE_PATH=/app/audio
 
 # S3-compatible storage config (only needed if DEFAULT_STORAGE_TYPE=s3)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,23 @@ services:
       S3_REGION: ${S3_REGION:-}
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-}
+
+      # SMTP (optional: password reset + email notifications)
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-}
+      SMTP_SECURE: ${SMTP_SECURE:-}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      SMTP_FROM: ${SMTP_FROM:-}
+      SMTP_MARKETING_FROM: ${SMTP_MARKETING_FROM:-}
+      SMTP_REPLY_TO: ${SMTP_REPLY_TO:-}
     volumes:
+      # Official compose defaults LOCAL_STORAGE_PATH to /app/audio.
+      # The app default without that override is ./storage → /app/storage
+      # in this image (WORKDIR /app). Persist both so neither path is
+      # wiped on container recreate.
       - audio:/app/audio
+      - storage:/app/storage
     depends_on:
       db:
         condition: service_healthy
@@ -71,4 +86,6 @@ volumes:
   pgdata:
     driver: local
   audio:
+    driver: local
+  storage:
     driver: local

--- a/src/lib/sync/auto-transcribe-state.ts
+++ b/src/lib/sync/auto-transcribe-state.ts
@@ -1,0 +1,82 @@
+import {
+    type AutoTranscribeRetryOptions,
+    listUntranscribedRecordingIds,
+} from "@/lib/sync/untranscribed";
+
+const inFlightAutoTranscribeIds = new Set<string>();
+const recentFailedAutoTranscribeIds = new Set<string>();
+
+function idsExcludedFromAutoTranscribeRetry(): string[] {
+    return [
+        ...new Set([
+            ...inFlightAutoTranscribeIds,
+            ...recentFailedAutoTranscribeIds,
+        ]),
+    ];
+}
+
+/**
+ * Claim ids for a process-local auto-transcribe pass. Already in-flight
+ * ids are skipped so overlapping syncs do not double-call the provider.
+ */
+export function claimAutoTranscribeIds(ids: readonly string[]): string[] {
+    const claimed: string[] = [];
+    for (const id of ids) {
+        if (inFlightAutoTranscribeIds.has(id)) continue;
+        inFlightAutoTranscribeIds.add(id);
+        claimed.push(id);
+    }
+    return claimed;
+}
+
+/** Release in-flight claims after the provider pass finishes. */
+export function releaseAutoTranscribeIds(ids: readonly string[]): void {
+    for (const id of ids) {
+        inFlightAutoTranscribeIds.delete(id);
+    }
+}
+
+/**
+ * Record whether an auto-transcribe attempt produced a transcript.
+ * Failures are excluded from the next newest-first retry window so
+ * older recordings still get an attempt. Success clears that exclusion.
+ */
+export function noteAutoTranscribeOutcome(
+    recordingId: string,
+    success: boolean,
+): void {
+    if (success) {
+        recentFailedAutoTranscribeIds.delete(recordingId);
+        return;
+    }
+    recentFailedAutoTranscribeIds.add(recordingId);
+}
+
+/**
+ * Newest-first retry ids, excluding in-flight and recently failed
+ * recordings. When that window is empty, recent failures are cleared
+ * so the next pass can wrap around.
+ */
+export async function listAutoTranscribeRetryIds(
+    userId: string,
+    options: Omit<AutoTranscribeRetryOptions, "excludeIds"> = {},
+): Promise<string[]> {
+    const ids = await listUntranscribedRecordingIds(userId, {
+        ...options,
+        excludeIds: idsExcludedFromAutoTranscribeRetry(),
+    });
+    if (ids.length > 0 || recentFailedAutoTranscribeIds.size === 0) {
+        return ids;
+    }
+    recentFailedAutoTranscribeIds.clear();
+    return listUntranscribedRecordingIds(userId, {
+        ...options,
+        excludeIds: idsExcludedFromAutoTranscribeRetry(),
+    });
+}
+
+/** Test-only: drop process-local in-flight and failure state. */
+export function resetAutoTranscribeStateForTests(): void {
+    inFlightAutoTranscribeIds.clear();
+    recentFailedAutoTranscribeIds.clear();
+}

--- a/src/lib/sync/auto-transcribe-state.ts
+++ b/src/lib/sync/auto-transcribe-state.ts
@@ -1,4 +1,5 @@
 import {
+    AUTO_TRANSCRIBE_RETRY_LIMIT,
     type AutoTranscribeRetryOptions,
     listUntranscribedRecordingIds,
 } from "@/lib/sync/untranscribed";
@@ -21,6 +22,18 @@ function failedIdsFor(userId: string): Set<string> {
 function excludeIdsForUser(userId: string): string[] {
     const failed = recentFailedByUser.get(userId);
     return [...new Set([...inFlightAutoTranscribeIds, ...(failed ?? [])])];
+}
+
+function takeOldestFailed(userId: string, count: number): string[] {
+    const failed = recentFailedByUser.get(userId);
+    if (!failed || count <= 0) return [];
+    const picked: string[] = [];
+    for (const id of failed) {
+        if (inFlightAutoTranscribeIds.has(id)) continue;
+        picked.push(id);
+        if (picked.length >= count) break;
+    }
+    return picked;
 }
 
 /**
@@ -73,26 +86,31 @@ export function noteAutoTranscribeOutcome(
 
 /**
  * Newest-first retry ids for one user, excluding in-flight and that
- * user's recently failed recordings. When that window is empty, only
- * that user's failures are cleared so the next pass can wrap around.
+ * user's recently failed recordings. Unused slots, or one slot when
+ * the newest window is full, are filled from that user's oldest
+ * failures so a stream of newer recordings cannot starve retries.
  */
 export async function listAutoTranscribeRetryIds(
     userId: string,
     options: Omit<AutoTranscribeRetryOptions, "excludeIds"> = {},
 ): Promise<string[]> {
-    const ids = await listUntranscribedRecordingIds(userId, {
+    const fresh = await listUntranscribedRecordingIds(userId, {
         ...options,
         excludeIds: excludeIdsForUser(userId),
     });
     const failed = recentFailedByUser.get(userId);
-    if (ids.length > 0 || !failed || failed.size === 0) {
-        return ids;
-    }
-    recentFailedByUser.delete(userId);
-    return listUntranscribedRecordingIds(userId, {
-        ...options,
-        excludeIds: excludeIdsForUser(userId),
-    });
+    const failedCount = failed?.size ?? 0;
+    if (failedCount === 0) return fresh;
+
+    const reserve =
+        fresh.length >= AUTO_TRANSCRIBE_RETRY_LIMIT
+            ? 1
+            : AUTO_TRANSCRIBE_RETRY_LIMIT - fresh.length;
+    const fromFailed = takeOldestFailed(userId, reserve);
+    return [
+        ...fresh.slice(0, AUTO_TRANSCRIBE_RETRY_LIMIT - fromFailed.length),
+        ...fromFailed,
+    ];
 }
 
 /** Test-only: drop process-local in-flight and failure state. */

--- a/src/lib/sync/auto-transcribe-state.ts
+++ b/src/lib/sync/auto-transcribe-state.ts
@@ -110,15 +110,17 @@ export async function listAutoTranscribeRetryIds(
         return fresh;
     }
 
+    if (recentFailedByUser.get(userId) !== failed) {
+        return fresh;
+    }
+
     const eligible = new Set(stillEligible);
-    if (recentFailedByUser.get(userId) === failed) {
-        for (const id of candidates) {
-            if (!eligible.has(id)) failed.delete(id);
-        }
-        if (failed.size === 0) {
-            recentFailedByUser.delete(userId);
-            return fresh;
-        }
+    for (const id of candidates) {
+        if (!eligible.has(id)) failed.delete(id);
+    }
+    if (failed.size === 0) {
+        recentFailedByUser.delete(userId);
+        return fresh;
     }
 
     const reserve =

--- a/src/lib/sync/auto-transcribe-state.ts
+++ b/src/lib/sync/auto-transcribe-state.ts
@@ -24,18 +24,6 @@ function excludeIdsForUser(userId: string): string[] {
     return [...new Set([...inFlightAutoTranscribeIds, ...(failed ?? [])])];
 }
 
-function takeOldestFailed(userId: string, count: number): string[] {
-    const failed = recentFailedByUser.get(userId);
-    if (!failed || count <= 0) return [];
-    const picked: string[] = [];
-    for (const id of failed) {
-        if (inFlightAutoTranscribeIds.has(id)) continue;
-        picked.push(id);
-        if (picked.length >= count) break;
-    }
-    return picked;
-}
-
 /**
  * Claim ids for a process-local auto-transcribe pass. Already in-flight
  * ids are skipped so overlapping syncs do not double-call the provider.
@@ -88,25 +76,59 @@ export function noteAutoTranscribeOutcome(
  * Newest-first retry ids for one user, excluding in-flight and that
  * user's recently failed recordings. Unused slots, or one slot when
  * the newest window is full, are filled from that user's oldest
- * failures so a stream of newer recordings cannot starve retries.
+ * still-eligible failures so a stream of newer recordings cannot
+ * starve retries. Deleted or already-transcribed failures are dropped.
  */
 export async function listAutoTranscribeRetryIds(
     userId: string,
-    options: Omit<AutoTranscribeRetryOptions, "excludeIds"> = {},
+    options: Omit<AutoTranscribeRetryOptions, "excludeIds" | "onlyIds"> = {},
 ): Promise<string[]> {
     const fresh = await listUntranscribedRecordingIds(userId, {
         ...options,
         excludeIds: excludeIdsForUser(userId),
     });
     const failed = recentFailedByUser.get(userId);
-    const failedCount = failed?.size ?? 0;
-    if (failedCount === 0) return fresh;
+    if (!failed || failed.size === 0) return fresh;
+
+    const candidates: string[] = [];
+    for (const id of failed) {
+        if (inFlightAutoTranscribeIds.has(id)) continue;
+        candidates.push(id);
+    }
+    if (candidates.length === 0) return fresh;
+
+    let stillEligible: string[];
+    try {
+        stillEligible = await listUntranscribedRecordingIds(userId, {
+            ...options,
+            excludeIds: [...inFlightAutoTranscribeIds],
+            onlyIds: candidates,
+            limit: candidates.length,
+        });
+    } catch (error) {
+        console.error("Auto-transcribe failure revalidation failed:", error);
+        return fresh;
+    }
+
+    const eligible = new Set(stillEligible);
+    for (const id of candidates) {
+        if (!eligible.has(id)) failed.delete(id);
+    }
+    if (failed.size === 0) {
+        recentFailedByUser.delete(userId);
+        return fresh;
+    }
 
     const reserve =
         fresh.length >= AUTO_TRANSCRIBE_RETRY_LIMIT
             ? 1
             : AUTO_TRANSCRIBE_RETRY_LIMIT - fresh.length;
-    const fromFailed = takeOldestFailed(userId, reserve);
+    const fromFailed: string[] = [];
+    for (const id of candidates) {
+        if (!eligible.has(id)) continue;
+        fromFailed.push(id);
+        if (fromFailed.length >= reserve) break;
+    }
     return [
         ...fresh.slice(0, AUTO_TRANSCRIBE_RETRY_LIMIT - fromFailed.length),
         ...fromFailed,

--- a/src/lib/sync/auto-transcribe-state.ts
+++ b/src/lib/sync/auto-transcribe-state.ts
@@ -111,12 +111,14 @@ export async function listAutoTranscribeRetryIds(
     }
 
     const eligible = new Set(stillEligible);
-    for (const id of candidates) {
-        if (!eligible.has(id)) failed.delete(id);
-    }
-    if (failed.size === 0) {
-        recentFailedByUser.delete(userId);
-        return fresh;
+    if (recentFailedByUser.get(userId) === failed) {
+        for (const id of candidates) {
+            if (!eligible.has(id)) failed.delete(id);
+        }
+        if (failed.size === 0) {
+            recentFailedByUser.delete(userId);
+            return fresh;
+        }
     }
 
     const reserve =

--- a/src/lib/sync/auto-transcribe-state.ts
+++ b/src/lib/sync/auto-transcribe-state.ts
@@ -3,16 +3,24 @@ import {
     listUntranscribedRecordingIds,
 } from "@/lib/sync/untranscribed";
 
-const inFlightAutoTranscribeIds = new Set<string>();
-const recentFailedAutoTranscribeIds = new Set<string>();
+/** Max remembered failed ids per user in this process. */
+export const AUTO_TRANSCRIBE_FAILED_ID_LIMIT = 256;
 
-function idsExcludedFromAutoTranscribeRetry(): string[] {
-    return [
-        ...new Set([
-            ...inFlightAutoTranscribeIds,
-            ...recentFailedAutoTranscribeIds,
-        ]),
-    ];
+const inFlightAutoTranscribeIds = new Set<string>();
+const recentFailedByUser = new Map<string, Set<string>>();
+
+function failedIdsFor(userId: string): Set<string> {
+    let failed = recentFailedByUser.get(userId);
+    if (!failed) {
+        failed = new Set();
+        recentFailedByUser.set(userId, failed);
+    }
+    return failed;
+}
+
+function excludeIdsForUser(userId: string): string[] {
+    const failed = recentFailedByUser.get(userId);
+    return [...new Set([...inFlightAutoTranscribeIds, ...(failed ?? [])])];
 }
 
 /**
@@ -38,24 +46,35 @@ export function releaseAutoTranscribeIds(ids: readonly string[]): void {
 
 /**
  * Record whether an auto-transcribe attempt produced a transcript.
- * Failures are excluded from the next newest-first retry window so
- * older recordings still get an attempt. Success clears that exclusion.
+ * Failures are excluded from that user's next newest-first retry window
+ * so older recordings still get an attempt. Success clears that exclusion.
  */
 export function noteAutoTranscribeOutcome(
+    userId: string,
     recordingId: string,
     success: boolean,
 ): void {
+    const failed = failedIdsFor(userId);
     if (success) {
-        recentFailedAutoTranscribeIds.delete(recordingId);
+        failed.delete(recordingId);
+        if (failed.size === 0) {
+            recentFailedByUser.delete(userId);
+        }
         return;
     }
-    recentFailedAutoTranscribeIds.add(recordingId);
+    failed.delete(recordingId);
+    failed.add(recordingId);
+    while (failed.size > AUTO_TRANSCRIBE_FAILED_ID_LIMIT) {
+        const oldest = failed.values().next().value;
+        if (oldest === undefined) break;
+        failed.delete(oldest);
+    }
 }
 
 /**
- * Newest-first retry ids, excluding in-flight and recently failed
- * recordings. When that window is empty, recent failures are cleared
- * so the next pass can wrap around.
+ * Newest-first retry ids for one user, excluding in-flight and that
+ * user's recently failed recordings. When that window is empty, only
+ * that user's failures are cleared so the next pass can wrap around.
  */
 export async function listAutoTranscribeRetryIds(
     userId: string,
@@ -63,20 +82,21 @@ export async function listAutoTranscribeRetryIds(
 ): Promise<string[]> {
     const ids = await listUntranscribedRecordingIds(userId, {
         ...options,
-        excludeIds: idsExcludedFromAutoTranscribeRetry(),
+        excludeIds: excludeIdsForUser(userId),
     });
-    if (ids.length > 0 || recentFailedAutoTranscribeIds.size === 0) {
+    const failed = recentFailedByUser.get(userId);
+    if (ids.length > 0 || !failed || failed.size === 0) {
         return ids;
     }
-    recentFailedAutoTranscribeIds.clear();
+    recentFailedByUser.delete(userId);
     return listUntranscribedRecordingIds(userId, {
         ...options,
-        excludeIds: idsExcludedFromAutoTranscribeRetry(),
+        excludeIds: excludeIdsForUser(userId),
     });
 }
 
 /** Test-only: drop process-local in-flight and failure state. */
 export function resetAutoTranscribeStateForTests(): void {
     inFlightAutoTranscribeIds.clear();
-    recentFailedAutoTranscribeIds.clear();
+    recentFailedByUser.clear();
 }

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -760,9 +760,9 @@ async function queueTranscriptions(
                 const outcome = await transcribeRecording(userId, recordingId, {
                     trigger: "sync",
                 });
-                noteAutoTranscribeOutcome(recordingId, outcome.success);
+                noteAutoTranscribeOutcome(userId, recordingId, outcome.success);
             } catch (error) {
-                noteAutoTranscribeOutcome(recordingId, false);
+                noteAutoTranscribeOutcome(userId, recordingId, false);
                 console.error(
                     `Auto-transcription failed for recording ${recordingId}:`,
                     error,

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -28,6 +28,7 @@ import {
     captureServerException,
 } from "@/lib/posthog-server";
 import { createUserStorageProvider } from "@/lib/storage/factory";
+import { listUntranscribedRecordingIds } from "@/lib/sync/untranscribed";
 import {
     upsertEnhancement,
     upsertTranscription,
@@ -680,17 +681,28 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
         // recordings that received a Plaud transcript (saves AI credits);
         // 'keep_both' runs anyway so both coexist. Recordings whose Plaud
         // transcript wasn't ready/failed fall back here naturally.
-        const idsToTranscribe =
-            context.transcriptMode === "keep_both"
-                ? result.pendingTranscriptionIds
-                : result.pendingTranscriptionIds.filter(
-                      (id) => !plaudTranscriptImported.has(id),
-                  );
+        if (context.autoTranscribe) {
+            let retryIds: string[] = [];
+            try {
+                retryIds = await listUntranscribedRecordingIds(userId);
+            } catch (error) {
+                console.error("Auto-transcribe retry lookup failed:", error);
+            }
+            const mergedIds = [
+                ...new Set([...result.pendingTranscriptionIds, ...retryIds]),
+            ];
+            const idsToTranscribe =
+                context.transcriptMode === "keep_both"
+                    ? mergedIds
+                    : mergedIds.filter(
+                          (id) => !plaudTranscriptImported.has(id),
+                      );
 
-        if (context.autoTranscribe && idsToTranscribe.length > 0) {
-            queueTranscriptions(userId, idsToTranscribe).catch((error) => {
-                console.error("Background transcription failed:", error);
-            });
+            if (idsToTranscribe.length > 0) {
+                queueTranscriptions(userId, idsToTranscribe).catch((error) => {
+                    console.error("Background transcription failed:", error);
+                });
+            }
         }
 
         return result;

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -684,13 +684,16 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
         if (context.autoTranscribe) {
             let retryIds: string[] = [];
             try {
-                retryIds = await listUntranscribedRecordingIds(userId);
+                retryIds = await listUntranscribedRecordingIds(userId, {
+                    transcriptMode: context.transcriptMode,
+                    excludeIds: [...inFlightAutoTranscribeIds],
+                });
             } catch (error) {
                 console.error("Auto-transcribe retry lookup failed:", error);
             }
             const mergedIds = [
                 ...new Set([...result.pendingTranscriptionIds, ...retryIds]),
-            ];
+            ].filter((id) => !inFlightAutoTranscribeIds.has(id));
             const idsToTranscribe =
                 context.transcriptMode === "keep_both"
                     ? mergedIds
@@ -742,18 +745,32 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
     }
 }
 
+const inFlightAutoTranscribeIds = new Set<string>();
+
 async function queueTranscriptions(
     userId: string,
     recordingIds: string[],
 ): Promise<void> {
-    for (const recordingId of recordingIds) {
-        try {
-            await transcribeRecording(userId, recordingId, { trigger: "sync" });
-        } catch (error) {
-            console.error(
-                `Auto-transcription failed for recording ${recordingId}:`,
-                error,
-            );
+    const ids = recordingIds.filter((id) => !inFlightAutoTranscribeIds.has(id));
+    for (const id of ids) {
+        inFlightAutoTranscribeIds.add(id);
+    }
+    try {
+        for (const recordingId of ids) {
+            try {
+                await transcribeRecording(userId, recordingId, {
+                    trigger: "sync",
+                });
+            } catch (error) {
+                console.error(
+                    `Auto-transcription failed for recording ${recordingId}:`,
+                    error,
+                );
+            }
+        }
+    } finally {
+        for (const id of ids) {
+            inFlightAutoTranscribeIds.delete(id);
         }
     }
 }

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -28,7 +28,12 @@ import {
     captureServerException,
 } from "@/lib/posthog-server";
 import { createUserStorageProvider } from "@/lib/storage/factory";
-import { listUntranscribedRecordingIds } from "@/lib/sync/untranscribed";
+import {
+    claimAutoTranscribeIds,
+    listAutoTranscribeRetryIds,
+    noteAutoTranscribeOutcome,
+    releaseAutoTranscribeIds,
+} from "@/lib/sync/auto-transcribe-state";
 import {
     upsertEnhancement,
     upsertTranscription,
@@ -684,22 +689,22 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
         if (context.autoTranscribe) {
             let retryIds: string[] = [];
             try {
-                retryIds = await listUntranscribedRecordingIds(userId, {
+                retryIds = await listAutoTranscribeRetryIds(userId, {
                     transcriptMode: context.transcriptMode,
-                    excludeIds: [...inFlightAutoTranscribeIds],
                 });
             } catch (error) {
                 console.error("Auto-transcribe retry lookup failed:", error);
             }
             const mergedIds = [
                 ...new Set([...result.pendingTranscriptionIds, ...retryIds]),
-            ].filter((id) => !inFlightAutoTranscribeIds.has(id));
-            const idsToTranscribe =
+            ];
+            const eligibleIds =
                 context.transcriptMode === "keep_both"
                     ? mergedIds
                     : mergedIds.filter(
                           (id) => !plaudTranscriptImported.has(id),
                       );
+            const idsToTranscribe = claimAutoTranscribeIds(eligibleIds);
 
             if (idsToTranscribe.length > 0) {
                 queueTranscriptions(userId, idsToTranscribe).catch((error) => {
@@ -745,23 +750,19 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
     }
 }
 
-const inFlightAutoTranscribeIds = new Set<string>();
-
 async function queueTranscriptions(
     userId: string,
     recordingIds: string[],
 ): Promise<void> {
-    const ids = recordingIds.filter((id) => !inFlightAutoTranscribeIds.has(id));
-    for (const id of ids) {
-        inFlightAutoTranscribeIds.add(id);
-    }
     try {
-        for (const recordingId of ids) {
+        for (const recordingId of recordingIds) {
             try {
-                await transcribeRecording(userId, recordingId, {
+                const outcome = await transcribeRecording(userId, recordingId, {
                     trigger: "sync",
                 });
+                noteAutoTranscribeOutcome(recordingId, outcome.success);
             } catch (error) {
+                noteAutoTranscribeOutcome(recordingId, false);
                 console.error(
                     `Auto-transcription failed for recording ${recordingId}:`,
                     error,
@@ -769,9 +770,7 @@ async function queueTranscriptions(
             }
         }
     } finally {
-        for (const id of ids) {
-            inFlightAutoTranscribeIds.delete(id);
-        }
+        releaseAutoTranscribeIds(recordingIds);
     }
 }
 

--- a/src/lib/sync/untranscribed.ts
+++ b/src/lib/sync/untranscribed.ts
@@ -1,0 +1,39 @@
+import { and, asc, eq, exists, isNull, not } from "drizzle-orm";
+import { db } from "@/db";
+import { recordings, transcriptions } from "@/db/schema";
+
+/** Max already-synced recordings without a transcript to retry per sync. */
+export const AUTO_TRANSCRIBE_RETRY_LIMIT = 5;
+
+/** Recording ids with no transcript row, oldest first. */
+export async function listUntranscribedRecordingIds(
+    userId: string,
+    limit = AUTO_TRANSCRIBE_RETRY_LIMIT,
+): Promise<string[]> {
+    const transcriptExists = exists(
+        db
+            .select({ id: transcriptions.id })
+            .from(transcriptions)
+            .where(
+                and(
+                    eq(transcriptions.recordingId, recordings.id),
+                    eq(transcriptions.userId, userId),
+                ),
+            ),
+    );
+
+    const rows = await db
+        .select({ id: recordings.id })
+        .from(recordings)
+        .where(
+            and(
+                eq(recordings.userId, userId),
+                isNull(recordings.deletedAt),
+                not(transcriptExists),
+            ),
+        )
+        .orderBy(asc(recordings.createdAt), asc(recordings.id))
+        .limit(limit);
+
+    return rows.map((row) => row.id);
+}

--- a/src/lib/sync/untranscribed.ts
+++ b/src/lib/sync/untranscribed.ts
@@ -1,38 +1,61 @@
-import { and, asc, eq, exists, isNull, not } from "drizzle-orm";
+import { and, desc, eq, exists, isNull, not, notInArray } from "drizzle-orm";
 import { db } from "@/db";
 import { recordings, transcriptions } from "@/db/schema";
 
-/** Max already-synced recordings without a transcript to retry per sync. */
+/** Max already-synced recordings to retry per sync. */
 export const AUTO_TRANSCRIBE_RETRY_LIMIT = 5;
 
-/** Recording ids with no transcript row, oldest first. */
+export type AutoTranscribeRetryOptions = {
+    transcriptMode?: string;
+    excludeIds?: readonly string[];
+    limit?: number;
+};
+
+/**
+ * Recording ids still eligible for auto-transcribe retry, newest first.
+ * `keep_both` requires a missing Riffado-source transcript. `plaud_only`
+ * (default) treats any transcript row as done.
+ */
 export async function listUntranscribedRecordingIds(
     userId: string,
-    limit = AUTO_TRANSCRIBE_RETRY_LIMIT,
+    options: AutoTranscribeRetryOptions = {},
 ): Promise<string[]> {
+    const limit = options.limit ?? AUTO_TRANSCRIBE_RETRY_LIMIT;
+    const keepBoth = options.transcriptMode === "keep_both";
+    const excludeIds = options.excludeIds ?? [];
+
+    const sourceMatch = keepBoth
+        ? and(
+              eq(transcriptions.recordingId, recordings.id),
+              eq(transcriptions.userId, userId),
+              eq(transcriptions.source, "riffado"),
+          )
+        : and(
+              eq(transcriptions.recordingId, recordings.id),
+              eq(transcriptions.userId, userId),
+          );
+
     const transcriptExists = exists(
         db
             .select({ id: transcriptions.id })
             .from(transcriptions)
-            .where(
-                and(
-                    eq(transcriptions.recordingId, recordings.id),
-                    eq(transcriptions.userId, userId),
-                ),
-            ),
+            .where(sourceMatch),
     );
+
+    const conditions = [
+        eq(recordings.userId, userId),
+        isNull(recordings.deletedAt),
+        not(transcriptExists),
+    ];
+    if (excludeIds.length > 0) {
+        conditions.push(notInArray(recordings.id, [...excludeIds]));
+    }
 
     const rows = await db
         .select({ id: recordings.id })
         .from(recordings)
-        .where(
-            and(
-                eq(recordings.userId, userId),
-                isNull(recordings.deletedAt),
-                not(transcriptExists),
-            ),
-        )
-        .orderBy(asc(recordings.createdAt), asc(recordings.id))
+        .where(and(...conditions))
+        .orderBy(desc(recordings.createdAt), desc(recordings.id))
         .limit(limit);
 
     return rows.map((row) => row.id);

--- a/src/lib/sync/untranscribed.ts
+++ b/src/lib/sync/untranscribed.ts
@@ -1,4 +1,13 @@
-import { and, desc, eq, exists, isNull, not, notInArray } from "drizzle-orm";
+import {
+    and,
+    desc,
+    eq,
+    exists,
+    inArray,
+    isNull,
+    not,
+    notInArray,
+} from "drizzle-orm";
 import { db } from "@/db";
 import { recordings, transcriptions } from "@/db/schema";
 
@@ -8,6 +17,8 @@ export const AUTO_TRANSCRIBE_RETRY_LIMIT = 5;
 export type AutoTranscribeRetryOptions = {
     transcriptMode?: string;
     excludeIds?: readonly string[];
+    /** When set, only these recording ids are considered. */
+    onlyIds?: readonly string[];
     limit?: number;
 };
 
@@ -23,6 +34,7 @@ export async function listUntranscribedRecordingIds(
     const limit = options.limit ?? AUTO_TRANSCRIBE_RETRY_LIMIT;
     const keepBoth = options.transcriptMode === "keep_both";
     const excludeIds = options.excludeIds ?? [];
+    const onlyIds = options.onlyIds ?? [];
 
     const sourceMatch = keepBoth
         ? and(
@@ -49,6 +61,9 @@ export async function listUntranscribedRecordingIds(
     ];
     if (excludeIds.length > 0) {
         conditions.push(notInArray(recordings.id, [...excludeIds]));
+    }
+    if (onlyIds.length > 0) {
+        conditions.push(inArray(recordings.id, [...onlyIds]));
     }
 
     const rows = await db

--- a/src/lib/webhooks/worker.ts
+++ b/src/lib/webhooks/worker.ts
@@ -371,7 +371,10 @@ export async function deliverDueWebhooks(): Promise<void> {
 }
 
 export function signalWebhookWorker(): void {
-    if (!started) return;
+    if (!started) {
+        startWebhookWorker();
+        return;
+    }
     void deliverDueWebhooks();
 }
 

--- a/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
+++ b/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/lib/sync/untranscribed", () => ({
 }));
 
 import {
+    AUTO_TRANSCRIBE_FAILED_ID_LIMIT,
     claimAutoTranscribeIds,
     listAutoTranscribeRetryIds,
     noteAutoTranscribeOutcome,
@@ -32,7 +33,7 @@ describe("issue #241: auto-transcribe retry rotation", () => {
     it("excludes recent failures from the next newest-first window", async () => {
         (listUntranscribedRecordingIds as Mock).mockResolvedValue(olderTwo);
         for (const id of newestFive) {
-            noteAutoTranscribeOutcome(id, false);
+            noteAutoTranscribeOutcome("user-1", id, false);
         }
 
         const ids = await listAutoTranscribeRetryIds("user-1", {
@@ -52,7 +53,7 @@ describe("issue #241: auto-transcribe retry rotation", () => {
             .mockResolvedValueOnce([])
             .mockResolvedValueOnce(newestFive);
         for (const id of newestFive) {
-            noteAutoTranscribeOutcome(id, false);
+            noteAutoTranscribeOutcome("user-1", id, false);
         }
 
         const ids = await listAutoTranscribeRetryIds("user-1");
@@ -82,8 +83,8 @@ describe("issue #241: auto-transcribe retry rotation", () => {
 
     it("drops a recording from the failure window after a later success", async () => {
         (listUntranscribedRecordingIds as Mock).mockResolvedValue(["n2"]);
-        noteAutoTranscribeOutcome("n1", false);
-        noteAutoTranscribeOutcome("n1", true);
+        noteAutoTranscribeOutcome("user-1", "n1", false);
+        noteAutoTranscribeOutcome("user-1", "n1", true);
 
         await listAutoTranscribeRetryIds("user-1");
 
@@ -96,7 +97,7 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         const claimed = claimAutoTranscribeIds(["busy"]);
         expect(claimed).toEqual(["busy"]);
         for (const id of newestFive) {
-            noteAutoTranscribeOutcome(id, false);
+            noteAutoTranscribeOutcome("user-1", id, false);
         }
         (listUntranscribedRecordingIds as Mock)
             .mockResolvedValueOnce([])
@@ -111,5 +112,50 @@ describe("issue #241: auto-transcribe retry rotation", () => {
             { excludeIds: ["busy"] },
         );
         releaseAutoTranscribeIds(claimed);
+    });
+
+    it("does not clear another user's failures on wrap-around", async () => {
+        for (const id of newestFive) {
+            noteAutoTranscribeOutcome("user-1", id, false);
+        }
+        noteAutoTranscribeOutcome("user-2", "b-fail", false);
+        (listUntranscribedRecordingIds as Mock)
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce(["b1"])
+            .mockResolvedValueOnce(olderTwo);
+
+        await listAutoTranscribeRetryIds("user-2");
+        await listAutoTranscribeRetryIds("user-1");
+
+        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
+            1,
+            "user-2",
+            { excludeIds: ["b-fail"] },
+        );
+        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
+            2,
+            "user-2",
+            { excludeIds: [] },
+        );
+        expect(listUntranscribedRecordingIds).toHaveBeenLastCalledWith(
+            "user-1",
+            { excludeIds: newestFive },
+        );
+    });
+
+    it("caps remembered failures per user", async () => {
+        for (let i = 0; i < AUTO_TRANSCRIBE_FAILED_ID_LIMIT + 1; i++) {
+            noteAutoTranscribeOutcome("user-1", `id-${i}`, false);
+        }
+        (listUntranscribedRecordingIds as Mock).mockResolvedValue(["kept"]);
+
+        await listAutoTranscribeRetryIds("user-1");
+
+        const excludeIds = (listUntranscribedRecordingIds as Mock).mock
+            .calls[0][1].excludeIds as string[];
+        expect(excludeIds).toHaveLength(AUTO_TRANSCRIBE_FAILED_ID_LIMIT);
+        expect(excludeIds).not.toContain("id-0");
+        expect(excludeIds).toContain("id-1");
+        expect(excludeIds).toContain(`id-${AUTO_TRANSCRIBE_FAILED_ID_LIMIT}`);
     });
 });

--- a/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
+++ b/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
@@ -26,14 +26,20 @@ const newestFive = ["n1", "n2", "n3", "n4", "n5"];
 const olderTwo = ["o1", "o2"];
 const incomingFive = ["new1", "new2", "new3", "new4", "new5"];
 
+function mockFreshThenEligible(fresh: string[], eligible: string[]) {
+    (listUntranscribedRecordingIds as Mock)
+        .mockResolvedValueOnce(fresh)
+        .mockResolvedValueOnce(eligible);
+}
+
 describe("issue #241: auto-transcribe retry rotation", () => {
     beforeEach(() => {
         resetAutoTranscribeStateForTests();
         vi.clearAllMocks();
     });
 
-    it("fills leftover slots from the oldest failures", async () => {
-        (listUntranscribedRecordingIds as Mock).mockResolvedValue(olderTwo);
+    it("fills leftover slots from the oldest still-eligible failures", async () => {
+        mockFreshThenEligible(olderTwo, newestFive);
         for (const id of newestFive) {
             noteAutoTranscribeOutcome("user-1", id, false);
         }
@@ -43,15 +49,29 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         });
 
         expect(ids).toEqual(["o1", "o2", "n1", "n2", "n3"]);
-        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(1);
-        expect(listUntranscribedRecordingIds).toHaveBeenCalledWith("user-1", {
-            transcriptMode: "plaud_only",
-            excludeIds: newestFive,
-        });
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(2);
+        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
+            1,
+            "user-1",
+            {
+                transcriptMode: "plaud_only",
+                excludeIds: newestFive,
+            },
+        );
+        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
+            2,
+            "user-1",
+            {
+                transcriptMode: "plaud_only",
+                excludeIds: [],
+                onlyIds: newestFive,
+                limit: 5,
+            },
+        );
     });
 
-    it("retries oldest failures when the newest-first window is empty", async () => {
-        (listUntranscribedRecordingIds as Mock).mockResolvedValue([]);
+    it("retries oldest eligible failures when the newest-first window is empty", async () => {
+        mockFreshThenEligible([], newestFive);
         for (const id of newestFive) {
             noteAutoTranscribeOutcome("user-1", id, false);
         }
@@ -59,14 +79,11 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         const ids = await listAutoTranscribeRetryIds("user-1");
 
         expect(ids).toEqual(newestFive);
-        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(1);
-        expect(listUntranscribedRecordingIds).toHaveBeenCalledWith("user-1", {
-            excludeIds: newestFive,
-        });
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(2);
     });
 
     it("reserves one slot for an older failure when newer recordings keep arriving", async () => {
-        (listUntranscribedRecordingIds as Mock).mockResolvedValue(incomingFive);
+        mockFreshThenEligible(incomingFive, newestFive);
         for (const id of newestFive) {
             noteAutoTranscribeOutcome("user-1", id, false);
         }
@@ -74,7 +91,7 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         const ids = await listAutoTranscribeRetryIds("user-1");
 
         expect(ids).toEqual(["new1", "new2", "new3", "new4", "n1"]);
-        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(1);
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(2);
     });
 
     it("does not inject failures when there were none", async () => {
@@ -94,6 +111,7 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         const ids = await listAutoTranscribeRetryIds("user-1");
 
         expect(ids).toEqual(["n2"]);
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(1);
         expect(listUntranscribedRecordingIds).toHaveBeenCalledWith("user-1", {
             excludeIds: [],
         });
@@ -105,12 +123,20 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         for (const id of newestFive) {
             noteAutoTranscribeOutcome("user-1", id, false);
         }
-        (listUntranscribedRecordingIds as Mock).mockResolvedValue([]);
+        mockFreshThenEligible([], ["n2", "n3", "n4", "n5"]);
 
         const ids = await listAutoTranscribeRetryIds("user-1");
 
         expect(ids).toEqual(["n2", "n3", "n4", "n5"]);
-        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(1);
+        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
+            2,
+            "user-1",
+            {
+                excludeIds: ["n1"],
+                onlyIds: ["n2", "n3", "n4", "n5"],
+                limit: 4,
+            },
+        );
         releaseAutoTranscribeIds(claimed);
     });
 
@@ -121,7 +147,9 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         noteAutoTranscribeOutcome("user-2", "b-fail", false);
         (listUntranscribedRecordingIds as Mock)
             .mockResolvedValueOnce([])
-            .mockResolvedValueOnce(olderTwo);
+            .mockResolvedValueOnce(["b-fail"])
+            .mockResolvedValueOnce(olderTwo)
+            .mockResolvedValueOnce(newestFive);
 
         const user2 = await listAutoTranscribeRetryIds("user-2");
         const user1 = await listAutoTranscribeRetryIds("user-1");
@@ -133,9 +161,29 @@ describe("issue #241: auto-transcribe retry rotation", () => {
             "user-2",
             { excludeIds: ["b-fail"] },
         );
-        expect(listUntranscribedRecordingIds).toHaveBeenLastCalledWith(
+        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
+            3,
             "user-1",
             { excludeIds: newestFive },
+        );
+    });
+
+    it("discards failed ids that are no longer eligible", async () => {
+        for (const id of newestFive) {
+            noteAutoTranscribeOutcome("user-1", id, false);
+        }
+        mockFreshThenEligible(olderTwo, []);
+
+        const first = await listAutoTranscribeRetryIds("user-1");
+        expect(first).toEqual(olderTwo);
+
+        (listUntranscribedRecordingIds as Mock).mockResolvedValue(["fresh"]);
+        const second = await listAutoTranscribeRetryIds("user-1");
+
+        expect(second).toEqual(["fresh"]);
+        expect(listUntranscribedRecordingIds).toHaveBeenLastCalledWith(
+            "user-1",
+            { excludeIds: [] },
         );
     });
 
@@ -143,7 +191,11 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         for (let i = 0; i < AUTO_TRANSCRIBE_FAILED_ID_LIMIT + 1; i++) {
             noteAutoTranscribeOutcome("user-1", `id-${i}`, false);
         }
-        (listUntranscribedRecordingIds as Mock).mockResolvedValue(["kept"]);
+        const remaining = Array.from(
+            { length: AUTO_TRANSCRIBE_FAILED_ID_LIMIT },
+            (_, i) => `id-${i + 1}`,
+        );
+        mockFreshThenEligible(["kept"], remaining);
 
         await listAutoTranscribeRetryIds("user-1");
 

--- a/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
+++ b/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
@@ -227,7 +227,7 @@ describe("issue #241: auto-transcribe retry rotation", () => {
             noteAutoTranscribeOutcome("user-1", id, true);
         }
         noteAutoTranscribeOutcome("user-1", "later", false);
-        resolveEligible([]);
+        resolveEligible(newestFive);
 
         expect(await pending).toEqual(olderTwo);
 

--- a/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
+++ b/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
@@ -8,6 +8,7 @@
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 vi.mock("@/lib/sync/untranscribed", () => ({
+    AUTO_TRANSCRIBE_RETRY_LIMIT: 5,
     listUntranscribedRecordingIds: vi.fn(),
 }));
 
@@ -23,6 +24,7 @@ import { listUntranscribedRecordingIds } from "@/lib/sync/untranscribed";
 
 const newestFive = ["n1", "n2", "n3", "n4", "n5"];
 const olderTwo = ["o1", "o2"];
+const incomingFive = ["new1", "new2", "new3", "new4", "new5"];
 
 describe("issue #241: auto-transcribe retry rotation", () => {
     beforeEach(() => {
@@ -30,7 +32,7 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         vi.clearAllMocks();
     });
 
-    it("excludes recent failures from the next newest-first window", async () => {
+    it("fills leftover slots from the oldest failures", async () => {
         (listUntranscribedRecordingIds as Mock).mockResolvedValue(olderTwo);
         for (const id of newestFive) {
             noteAutoTranscribeOutcome("user-1", id, false);
@@ -40,7 +42,7 @@ describe("issue #241: auto-transcribe retry rotation", () => {
             transcriptMode: "plaud_only",
         });
 
-        expect(ids).toEqual(olderTwo);
+        expect(ids).toEqual(["o1", "o2", "n1", "n2", "n3"]);
         expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(1);
         expect(listUntranscribedRecordingIds).toHaveBeenCalledWith("user-1", {
             transcriptMode: "plaud_only",
@@ -48,10 +50,8 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         });
     });
 
-    it("wraps around and retries failures after the rest of the backlog is empty", async () => {
-        (listUntranscribedRecordingIds as Mock)
-            .mockResolvedValueOnce([])
-            .mockResolvedValueOnce(newestFive);
+    it("retries oldest failures when the newest-first window is empty", async () => {
+        (listUntranscribedRecordingIds as Mock).mockResolvedValue([]);
         for (const id of newestFive) {
             noteAutoTranscribeOutcome("user-1", id, false);
         }
@@ -59,20 +59,25 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         const ids = await listAutoTranscribeRetryIds("user-1");
 
         expect(ids).toEqual(newestFive);
-        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(2);
-        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
-            1,
-            "user-1",
-            { excludeIds: newestFive },
-        );
-        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
-            2,
-            "user-1",
-            { excludeIds: [] },
-        );
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(1);
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledWith("user-1", {
+            excludeIds: newestFive,
+        });
     });
 
-    it("does not wrap around when there were no recent failures", async () => {
+    it("reserves one slot for an older failure when newer recordings keep arriving", async () => {
+        (listUntranscribedRecordingIds as Mock).mockResolvedValue(incomingFive);
+        for (const id of newestFive) {
+            noteAutoTranscribeOutcome("user-1", id, false);
+        }
+
+        const ids = await listAutoTranscribeRetryIds("user-1");
+
+        expect(ids).toEqual(["new1", "new2", "new3", "new4", "n1"]);
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not inject failures when there were none", async () => {
         (listUntranscribedRecordingIds as Mock).mockResolvedValue([]);
 
         const ids = await listAutoTranscribeRetryIds("user-1");
@@ -86,56 +91,47 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         noteAutoTranscribeOutcome("user-1", "n1", false);
         noteAutoTranscribeOutcome("user-1", "n1", true);
 
-        await listAutoTranscribeRetryIds("user-1");
+        const ids = await listAutoTranscribeRetryIds("user-1");
 
+        expect(ids).toEqual(["n2"]);
         expect(listUntranscribedRecordingIds).toHaveBeenCalledWith("user-1", {
             excludeIds: [],
         });
     });
 
-    it("keeps in-flight ids excluded even after the failure window wraps", async () => {
-        const claimed = claimAutoTranscribeIds(["busy"]);
-        expect(claimed).toEqual(["busy"]);
+    it("skips in-flight ids when filling from the failure window", async () => {
+        const claimed = claimAutoTranscribeIds(["n1"]);
+        expect(claimed).toEqual(["n1"]);
         for (const id of newestFive) {
             noteAutoTranscribeOutcome("user-1", id, false);
         }
-        (listUntranscribedRecordingIds as Mock)
-            .mockResolvedValueOnce([])
-            .mockResolvedValueOnce(["o1"]);
+        (listUntranscribedRecordingIds as Mock).mockResolvedValue([]);
 
         const ids = await listAutoTranscribeRetryIds("user-1");
 
-        expect(ids).toEqual(["o1"]);
-        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
-            2,
-            "user-1",
-            { excludeIds: ["busy"] },
-        );
+        expect(ids).toEqual(["n2", "n3", "n4", "n5"]);
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(1);
         releaseAutoTranscribeIds(claimed);
     });
 
-    it("does not clear another user's failures on wrap-around", async () => {
+    it("does not consume another user's failures when filling slots", async () => {
         for (const id of newestFive) {
             noteAutoTranscribeOutcome("user-1", id, false);
         }
         noteAutoTranscribeOutcome("user-2", "b-fail", false);
         (listUntranscribedRecordingIds as Mock)
             .mockResolvedValueOnce([])
-            .mockResolvedValueOnce(["b1"])
             .mockResolvedValueOnce(olderTwo);
 
-        await listAutoTranscribeRetryIds("user-2");
-        await listAutoTranscribeRetryIds("user-1");
+        const user2 = await listAutoTranscribeRetryIds("user-2");
+        const user1 = await listAutoTranscribeRetryIds("user-1");
 
+        expect(user2).toEqual(["b-fail"]);
+        expect(user1).toEqual(["o1", "o2", "n1", "n2", "n3"]);
         expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
             1,
             "user-2",
             { excludeIds: ["b-fail"] },
-        );
-        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
-            2,
-            "user-2",
-            { excludeIds: [] },
         );
         expect(listUntranscribedRecordingIds).toHaveBeenLastCalledWith(
             "user-1",

--- a/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
+++ b/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
@@ -206,4 +206,38 @@ describe("issue #241: auto-transcribe retry rotation", () => {
         expect(excludeIds).toContain("id-1");
         expect(excludeIds).toContain(`id-${AUTO_TRANSCRIBE_FAILED_ID_LIMIT}`);
     });
+
+    it("does not drop a newer failure set replaced during revalidation", async () => {
+        for (const id of newestFive) {
+            noteAutoTranscribeOutcome("user-1", id, false);
+        }
+        let resolveEligible: (ids: string[]) => void = () => {};
+        (listUntranscribedRecordingIds as Mock)
+            .mockResolvedValueOnce(olderTwo)
+            .mockImplementationOnce(
+                () =>
+                    new Promise<string[]>((resolve) => {
+                        resolveEligible = resolve;
+                    }),
+            );
+
+        const pending = listAutoTranscribeRetryIds("user-1");
+        await Promise.resolve();
+        for (const id of newestFive) {
+            noteAutoTranscribeOutcome("user-1", id, true);
+        }
+        noteAutoTranscribeOutcome("user-1", "later", false);
+        resolveEligible([]);
+
+        expect(await pending).toEqual(olderTwo);
+
+        mockFreshThenEligible(["fresh"], ["later"]);
+        const next = await listAutoTranscribeRetryIds("user-1");
+        expect(next).toEqual(["fresh", "later"]);
+        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
+            3,
+            "user-1",
+            { excludeIds: ["later"] },
+        );
+    });
 });

--- a/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
+++ b/src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression for issue #241 auto-transcribe retry starvation.
+ * A newest-first limit of 5 must rotate past persistent failures so
+ * older transcriptless recordings still get an attempt. Process-local
+ * only — no attempt-status schema.
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/lib/sync/untranscribed", () => ({
+    listUntranscribedRecordingIds: vi.fn(),
+}));
+
+import {
+    claimAutoTranscribeIds,
+    listAutoTranscribeRetryIds,
+    noteAutoTranscribeOutcome,
+    releaseAutoTranscribeIds,
+    resetAutoTranscribeStateForTests,
+} from "@/lib/sync/auto-transcribe-state";
+import { listUntranscribedRecordingIds } from "@/lib/sync/untranscribed";
+
+const newestFive = ["n1", "n2", "n3", "n4", "n5"];
+const olderTwo = ["o1", "o2"];
+
+describe("issue #241: auto-transcribe retry rotation", () => {
+    beforeEach(() => {
+        resetAutoTranscribeStateForTests();
+        vi.clearAllMocks();
+    });
+
+    it("excludes recent failures from the next newest-first window", async () => {
+        (listUntranscribedRecordingIds as Mock).mockResolvedValue(olderTwo);
+        for (const id of newestFive) {
+            noteAutoTranscribeOutcome(id, false);
+        }
+
+        const ids = await listAutoTranscribeRetryIds("user-1", {
+            transcriptMode: "plaud_only",
+        });
+
+        expect(ids).toEqual(olderTwo);
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(1);
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledWith("user-1", {
+            transcriptMode: "plaud_only",
+            excludeIds: newestFive,
+        });
+    });
+
+    it("wraps around and retries failures after the rest of the backlog is empty", async () => {
+        (listUntranscribedRecordingIds as Mock)
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce(newestFive);
+        for (const id of newestFive) {
+            noteAutoTranscribeOutcome(id, false);
+        }
+
+        const ids = await listAutoTranscribeRetryIds("user-1");
+
+        expect(ids).toEqual(newestFive);
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(2);
+        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
+            1,
+            "user-1",
+            { excludeIds: newestFive },
+        );
+        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
+            2,
+            "user-1",
+            { excludeIds: [] },
+        );
+    });
+
+    it("does not wrap around when there were no recent failures", async () => {
+        (listUntranscribedRecordingIds as Mock).mockResolvedValue([]);
+
+        const ids = await listAutoTranscribeRetryIds("user-1");
+
+        expect(ids).toEqual([]);
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops a recording from the failure window after a later success", async () => {
+        (listUntranscribedRecordingIds as Mock).mockResolvedValue(["n2"]);
+        noteAutoTranscribeOutcome("n1", false);
+        noteAutoTranscribeOutcome("n1", true);
+
+        await listAutoTranscribeRetryIds("user-1");
+
+        expect(listUntranscribedRecordingIds).toHaveBeenCalledWith("user-1", {
+            excludeIds: [],
+        });
+    });
+
+    it("keeps in-flight ids excluded even after the failure window wraps", async () => {
+        const claimed = claimAutoTranscribeIds(["busy"]);
+        expect(claimed).toEqual(["busy"]);
+        for (const id of newestFive) {
+            noteAutoTranscribeOutcome(id, false);
+        }
+        (listUntranscribedRecordingIds as Mock)
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce(["o1"]);
+
+        const ids = await listAutoTranscribeRetryIds("user-1");
+
+        expect(ids).toEqual(["o1"]);
+        expect(listUntranscribedRecordingIds).toHaveBeenNthCalledWith(
+            2,
+            "user-1",
+            { excludeIds: ["busy"] },
+        );
+        releaseAutoTranscribeIds(claimed);
+    });
+});

--- a/src/tests/regressions/241-compose-storage-smtp.test.ts
+++ b/src/tests/regressions/241-compose-storage-smtp.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Regression test for issue #241 (bugs 4 and 5): the published
+ * docker-compose.yml dropped SMTP_* from the app environment (Compose
+ * interpolates `.env` for `${VAR}` but does not inject those vars into
+ * the container unless they are listed) and only volume-mounted
+ * `/app/audio`. The app default `LOCAL_STORAGE_PATH` is `./storage`,
+ * which is `/app/storage` in the image, so redeploy wiped audio.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const compose = readFileSync(join(process.cwd(), "docker-compose.yml"), "utf8");
+
+describe("issue #241: official compose persist + SMTP passthrough", () => {
+    it("forwards SMTP_* from .env into the app container", () => {
+        for (const key of [
+            "SMTP_HOST",
+            "SMTP_PORT",
+            "SMTP_SECURE",
+            "SMTP_USER",
+            "SMTP_PASSWORD",
+            "SMTP_FROM",
+            "SMTP_MARKETING_FROM",
+            "SMTP_REPLY_TO",
+        ]) {
+            expect(compose).toContain(`${key}: \${${key}:-}`);
+        }
+    });
+
+    it("persists both /app/audio and /app/storage", () => {
+        expect(compose).toContain("- audio:/app/audio");
+        expect(compose).toContain("- storage:/app/storage");
+        expect(compose).toMatch(/^\s{2}audio:\s*$/m);
+        expect(compose).toMatch(/^\s{2}storage:\s*$/m);
+    });
+});

--- a/src/tests/regressions/241-untranscribed-retry-source.test.ts
+++ b/src/tests/regressions/241-untranscribed-retry-source.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression for issue #241 auto-transcribe retry eligibility.
+ * keep_both must require a missing Riffado-source transcript; plaud_only
+ * treats any transcript row as done. Exercises the real query builder,
+ * not the sync.test.ts mock of listUntranscribedRecordingIds.
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+    },
+}));
+
+import { db } from "@/db";
+import { transcriptions } from "@/db/schema";
+import { listUntranscribedRecordingIds } from "@/lib/sync/untranscribed";
+
+function exprReferences(
+    expr: unknown,
+    target: unknown,
+    seen = new Set<unknown>(),
+): boolean {
+    if (expr == null) return false;
+    if (expr === target) return true;
+    if (typeof expr !== "object") return false;
+    if (seen.has(expr)) return false;
+    seen.add(expr);
+    for (const key of [
+        "queryChunks",
+        "sql",
+        "left",
+        "right",
+        "value",
+        "args",
+        "chunks",
+        "expr",
+    ]) {
+        const value = (expr as Record<string, unknown>)[key];
+        if (Array.isArray(value)) {
+            if (value.some((item) => exprReferences(item, target, seen))) {
+                return true;
+            }
+        } else if (exprReferences(value, target, seen)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function captureWhereExprs(): unknown[] {
+    const whereExprs: unknown[] = [];
+    (db.select as Mock).mockImplementation(() => {
+        const chain: {
+            from: Mock;
+            where: Mock;
+            orderBy: Mock;
+            limit: Mock;
+        } = {
+            from: vi.fn(),
+            where: vi.fn(),
+            orderBy: vi.fn(),
+            limit: vi.fn().mockResolvedValue([]),
+        };
+        chain.from.mockReturnValue(chain);
+        chain.where.mockImplementation((expr: unknown) => {
+            whereExprs.push(expr);
+            return chain;
+        });
+        chain.orderBy.mockReturnValue(chain);
+        return chain;
+    });
+    return whereExprs;
+}
+
+describe("issue #241: auto-transcribe retry source predicate", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("plaud_only exists-check does not scope to the riffado source", async () => {
+        const whereExprs = captureWhereExprs();
+        await listUntranscribedRecordingIds("user-1", {
+            transcriptMode: "plaud_only",
+        });
+        const existsWhere = whereExprs[0];
+        expect(existsWhere).toBeDefined();
+        expect(exprReferences(existsWhere, transcriptions.userId)).toBe(true);
+        expect(exprReferences(existsWhere, transcriptions.source)).toBe(false);
+        expect(exprReferences(existsWhere, "riffado")).toBe(false);
+    });
+
+    it("keep_both exists-check requires a missing riffado-source transcript", async () => {
+        const whereExprs = captureWhereExprs();
+        await listUntranscribedRecordingIds("user-1", {
+            transcriptMode: "keep_both",
+        });
+        const existsWhere = whereExprs[0];
+        expect(existsWhere).toBeDefined();
+        expect(exprReferences(existsWhere, transcriptions.userId)).toBe(true);
+        expect(exprReferences(existsWhere, transcriptions.source)).toBe(true);
+        expect(exprReferences(existsWhere, "riffado")).toBe(true);
+    });
+});

--- a/src/tests/regressions/241-webhook-signal-starts-worker.test.ts
+++ b/src/tests/regressions/241-webhook-signal-starts-worker.test.ts
@@ -3,27 +3,48 @@
  * `pending` with 0 attempts, including after Redeliver. Redeliver and
  * emit both call `signalWebhookWorker()`, which previously returned
  * immediately when `started` was false.
- *
- * That happens when `register()` in instrumentation never ran in this
- * module graph (standalone scan miss, #181) or the route handler got a
- * different worker singleton than the boot hook. Kick the worker on
- * first signal so an explicit Redeliver cannot no-op.
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const { claimDueWebhookDeliveries } = vi.hoisted(() => ({
+    claimDueWebhookDeliveries: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        execute: vi.fn(),
+        select: vi.fn(),
+        update: vi.fn(),
+        transaction: vi.fn(),
+    },
+}));
+
+vi.mock("@/db/queries/webhook-deliveries", () => ({
+    claimDueWebhookDeliveries,
+    releaseClaimedDelivery: vi.fn(),
+    reloadClaimedDeliveryForSend: vi.fn(),
+}));
+
+vi.mock("@/lib/posthog-server", () => ({
+    captureServerException: vi.fn(),
+}));
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        IS_HOSTED: false,
+        APP_URL: "http://localhost:3000",
+        WEBHOOKS_REQUIRE_PUBLIC_TARGETS: undefined,
+    },
+}));
+
+import { signalWebhookWorker } from "@/lib/webhooks/worker";
 
 describe("issue #241: webhook signal starts an unstarted worker", () => {
-    it("signalWebhookWorker calls startWebhookWorker when !started", () => {
-        const source = readFileSync(
-            join(process.cwd(), "src/lib/webhooks/worker.ts"),
-            "utf8",
-        );
-        const signal = source.match(
-            /export function signalWebhookWorker\(\): void \{[\s\S]*?\n\}/,
-        );
-        expect(signal?.[0]).toContain("if (!started)");
-        expect(signal?.[0]).toContain("startWebhookWorker()");
+    it("first signal runs a delivery pass", async () => {
+        signalWebhookWorker();
+        await vi.waitFor(() => {
+            expect(claimDueWebhookDeliveries).toHaveBeenCalled();
+        });
     });
 });

--- a/src/tests/regressions/241-webhook-signal-starts-worker.test.ts
+++ b/src/tests/regressions/241-webhook-signal-starts-worker.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for issue #241 (bug 2): webhook deliveries sat
+ * `pending` with 0 attempts, including after Redeliver. Redeliver and
+ * emit both call `signalWebhookWorker()`, which previously returned
+ * immediately when `started` was false.
+ *
+ * That happens when `register()` in instrumentation never ran in this
+ * module graph (standalone scan miss, #181) or the route handler got a
+ * different worker singleton than the boot hook. Kick the worker on
+ * first signal so an explicit Redeliver cannot no-op.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("issue #241: webhook signal starts an unstarted worker", () => {
+    it("signalWebhookWorker calls startWebhookWorker when !started", () => {
+        const source = readFileSync(
+            join(process.cwd(), "src/lib/webhooks/worker.ts"),
+            "utf8",
+        );
+        const signal = source.match(
+            /export function signalWebhookWorker\(\): void \{[\s\S]*?\n\}/,
+        );
+        expect(signal?.[0]).toContain("if (!started)");
+        expect(signal?.[0]).toContain("startWebhookWorker()");
+    });
+});

--- a/src/tests/sync.test.ts
+++ b/src/tests/sync.test.ts
@@ -40,6 +40,10 @@ vi.mock("@/lib/transcription/transcribe-recording", () => ({
     transcribeRecording: vi.fn().mockResolvedValue({ success: true }),
 }));
 
+vi.mock("@/lib/sync/untranscribed", () => ({
+    listUntranscribedRecordingIds: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("@/lib/webhooks/emit", () => ({
     emitEvent: vi.fn().mockResolvedValue(undefined),
 }));
@@ -53,6 +57,8 @@ import { db } from "@/db";
 import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { captureServerException } from "@/lib/posthog-server";
 import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
+import { listUntranscribedRecordingIds } from "@/lib/sync/untranscribed";
+import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
 
 describe("Sync", () => {
     const mockUserId = "user-123";
@@ -161,6 +167,100 @@ describe("Sync", () => {
 
             expect(result.newRecordings).toBe(0);
             expect(result.updatedRecordings).toBe(0);
+        });
+
+        it("retries already-synced recordings that still have no transcript when auto-transcribe is on", async () => {
+            const mockConnection = {
+                id: "conn-1",
+                userId: mockUserId,
+                bearerToken: "encrypted-token",
+            };
+            const mockExistingRecording = {
+                id: "local-rec-1",
+                plaudFileId: "plaud-1",
+                plaudVersion: "1000",
+            };
+            const mockPlaudClient = {
+                getRecordings: vi.fn().mockResolvedValue({
+                    data_file_list: [
+                        {
+                            id: "plaud-1",
+                            filename: "Recording 1.mp3",
+                            duration: 60000,
+                            start_time: "2024-01-01T10:00:00Z",
+                            end_time: "2024-01-01T10:01:00Z",
+                            filesize: 1024000,
+                            file_md5: "abc123",
+                            serial_number: "SN123",
+                            version_ms: 1000,
+                            timezone: 0,
+                            zonemins: 0,
+                            scene: 0,
+                            is_trash: false,
+                        },
+                    ],
+                }),
+                downloadRecording: vi
+                    .fn()
+                    .mockResolvedValue(Buffer.from("audio")),
+            };
+            (createPlaudClient as Mock).mockResolvedValue(mockPlaudClient);
+            (listUntranscribedRecordingIds as Mock).mockResolvedValueOnce([
+                "local-rec-1",
+            ]);
+            (db.update as Mock).mockReturnValue({
+                set: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue(undefined),
+                }),
+            });
+
+            (db.select as Mock)
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi.fn().mockResolvedValue([mockConnection]),
+                        }),
+                    }),
+                })
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi
+                                .fn()
+                                .mockResolvedValue([{ autoTranscribe: true }]),
+                        }),
+                    }),
+                })
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi
+                                .fn()
+                                .mockResolvedValue([
+                                    { email: "test@example.com" },
+                                ]),
+                        }),
+                    }),
+                })
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi
+                                .fn()
+                                .mockResolvedValue([mockExistingRecording]),
+                        }),
+                    }),
+                });
+
+            await syncRecordingsForUser(mockUserId);
+
+            await vi.waitFor(() => {
+                expect(transcribeRecording).toHaveBeenCalledWith(
+                    mockUserId,
+                    "local-rec-1",
+                    { trigger: "sync" },
+                );
+            });
         });
 
         it("should update recordings with newer version", async () => {

--- a/src/tests/sync.test.ts
+++ b/src/tests/sync.test.ts
@@ -254,6 +254,13 @@ describe("Sync", () => {
 
             await syncRecordingsForUser(mockUserId);
 
+            expect(listUntranscribedRecordingIds).toHaveBeenCalledWith(
+                mockUserId,
+                {
+                    transcriptMode: "plaud_only",
+                    excludeIds: [],
+                },
+            );
             await vi.waitFor(() => {
                 expect(transcribeRecording).toHaveBeenCalledWith(
                     mockUserId,
@@ -261,6 +268,67 @@ describe("Sync", () => {
                     { trigger: "sync" },
                 );
             });
+        });
+
+        it("asks the retry lookup for missing Riffado transcripts in keep_both mode", async () => {
+            const mockPlaudClient = {
+                getRecordings: vi.fn().mockResolvedValue({
+                    data_file_list: [],
+                }),
+            };
+            (createPlaudClient as Mock).mockResolvedValue(mockPlaudClient);
+            (db.update as Mock).mockReturnValue({
+                set: vi.fn().mockReturnValue({
+                    where: vi.fn().mockResolvedValue(undefined),
+                }),
+            });
+            (db.select as Mock)
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi.fn().mockResolvedValue([
+                                {
+                                    id: "conn-1",
+                                    userId: mockUserId,
+                                    bearerToken: "encrypted-token",
+                                },
+                            ]),
+                        }),
+                    }),
+                })
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi.fn().mockResolvedValue([
+                                {
+                                    autoTranscribe: true,
+                                    transcriptMode: "keep_both",
+                                },
+                            ]),
+                        }),
+                    }),
+                })
+                .mockReturnValueOnce({
+                    from: vi.fn().mockReturnValue({
+                        where: vi.fn().mockReturnValue({
+                            limit: vi
+                                .fn()
+                                .mockResolvedValue([
+                                    { email: "test@example.com" },
+                                ]),
+                        }),
+                    }),
+                });
+
+            await syncRecordingsForUser(mockUserId);
+
+            expect(listUntranscribedRecordingIds).toHaveBeenCalledWith(
+                mockUserId,
+                {
+                    transcriptMode: "keep_both",
+                    excludeIds: [],
+                },
+            );
         });
 
         it("should update recordings with newer version", async () => {

--- a/src/tests/sync.test.ts
+++ b/src/tests/sync.test.ts
@@ -56,6 +56,7 @@ vi.mock("@/lib/posthog-server", () => ({
 import { db } from "@/db";
 import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { captureServerException } from "@/lib/posthog-server";
+import { resetAutoTranscribeStateForTests } from "@/lib/sync/auto-transcribe-state";
 import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
 import { listUntranscribedRecordingIds } from "@/lib/sync/untranscribed";
 import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
@@ -64,6 +65,7 @@ describe("Sync", () => {
     const mockUserId = "user-123";
 
     beforeEach(() => {
+        resetAutoTranscribeStateForTests();
         vi.clearAllMocks();
     });
 

--- a/src/tests/sync.test.ts
+++ b/src/tests/sync.test.ts
@@ -41,6 +41,7 @@ vi.mock("@/lib/transcription/transcribe-recording", () => ({
 }));
 
 vi.mock("@/lib/sync/untranscribed", () => ({
+    AUTO_TRANSCRIBE_RETRY_LIMIT: 5,
     listUntranscribedRecordingIds: vi.fn().mockResolvedValue([]),
 }));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Scope

#241 only. Five holes, nothing else.

1. Auto-transcribe can skip a recording forever after the insert-time queue miss
2. Webhook `signalWebhookWorker()` no-ops when this singleton was never started (Redeliver stays at 0 attempts)
3. `/reset-password` client/server crash — already fixed on `main` (`7a289e1`); no change here
4. Official compose persists `/app/storage` (keeps `/app/audio`)
5. Official compose forwards `SMTP_*`

Not in this PR: Synology/btrfs (#259), China/plaud.cn (#273), #279, installer rewrite, extra env passthrough, hosted/worker architecture, persisted retry-backoff schema.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #241

## What landed

**Compose (4, 5).** Named volume `storage:/app/storage`; keep `audio:/app/audio`. Forward `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM`, `SMTP_MARKETING_FROM`, `SMTP_REPLY_TO`. Default `LOCAL_STORAGE_PATH` stays `/app/audio` so existing audio-volume deploys do not switch directories.

**Reset (3).** Already on `main`. `resetPasswordMode` lives in `src/lib/auth/reset-password-mode.ts` (no `"use client"`). Guarded by `src/tests/regressions/241-reset-password-page-crash.test.ts`.

**Webhooks (2).** `signalWebhookWorker()` starts the worker on first call if `started` is false. Regression test now calls `signalWebhookWorker` and asserts a delivery pass. Did not reproduce a live `register()` miss against `ghcr latest`.

**Auto-transcribe (1).** Auto-transcribe only queued IDs inserted in the current sync. Same-version skip never retries. When `autoTranscribe` is on, each sync also retries up to 5 newest eligible recordings. `keep_both` requires a missing Riffado-source transcript (Plaud-only import no longer suppresses the provider run). `plaud_only` still treats any transcript row as done. In-process in-flight ids are skipped so overlapping syncs do not start a second provider call.

Persistent failures no longer starve older recordings: they are excluded from the newest-first SQL window, leftover slots are filled from that user's oldest still-eligible failures, and when the newest window is full one slot is reserved for an older failure. Failed ids are revalidated before reuse so deleted or already-transcribed recordings are dropped. Failure memory is per-user and capped at 256 ids. Process-local only (lost on restart). No attempt-status table.

`src/tests/regressions/241-untranscribed-retry-source.test.ts` runs the real `listUntranscribedRecordingIds` builder and asserts the `keep_both` exists-check includes `transcriptions.source = riffado` while `plaud_only` does not. `src/tests/regressions/241-auto-transcribe-retry-rotation.test.ts` covers reserved-slot retry, stale-id discard, per-user isolation, and the cap.

## Testing

- `pnpm format-and-lint:fix && pnpm type-check`
- `vitest run` on `src/tests/sync.test.ts` and the #241 regression files

Not run: live Plaud sync, compose stack, deploy.

## Additional Notes

Files already lost on a previous recreate are not recoverable. Pull + recreate attaches the new `storage` volume. Do not merge from this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6edac533-b04a-414a-be72-580cbd87ad78?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6edac533-b04a-414a-be72-580cbd87ad78&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents audio loss on redeploys, forwards SMTP settings for email, fixes auto-transcribe so missed/starved recordings get processed, and makes Redeliver actually send by starting the webhook worker when signaled.

- Bug Fixes
  - Persist `/app/storage` with `storage:/app/storage`; keep `audio:/app/audio`.
  - Pass `SMTP_*` env vars into the app container.
  - Auto-transcribe retries up to 5 per sync: skip in-flight IDs, rotate failures per user (cap 256) with one reserved slot for older items, revalidate IDs and ignore stale results if the failure set changed, and honor transcript mode (`keep_both` requires a missing Riffado transcript; `plaud_only` treats any transcript as done).
  - Start the webhook worker in `signalWebhookWorker()` if not running so Redeliver increments attempts and delivers.

- Migration
  - Pull and recreate the stack to attach the new `storage` volume; the `audio` volume remains.
  - Set `SMTP_*` in `.env` if you use email; compose now forwards them.

<sup>Written for commit 97295ad0ed7605614eb92f720fadc5eb222c6292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

