### PR TITLE
fix(docker): install image deps with pnpm, not bun

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
-# Base image with Bun
-FROM oven/bun:1 AS base
+# Pin bun. `oven/bun:1` floated to 1.4.0, which migrates `pnpm-lock.yaml`
+# and then fails `--frozen-lockfile` ("lockfile had changes").
+FROM oven/bun:1.4.0 AS base
 WORKDIR /app
 
-# Install dependencies
+# Install with pnpm, same pin as hosted CI (`.github/workflows/ci.yml`).
+# bun 1.4.0 cannot consume this repo's pnpm lock under `--frozen-lockfile`.
 # `--ignore-scripts` skips the `fumadocs-mdx` postinstall (declared in
 # package.json by PR #131). That hook needs `source.config.ts` and
 # `content/docs/`, which aren't present in this hermetic deps stage --
-# only `package.json` + the lockfile are. We regenerate fumadocs sources
-# explicitly in the builder stage below, where the full tree is available.
-FROM base AS deps
-COPY package.json pnpm-lock.yaml ./
-RUN bun install --frozen-lockfile --ignore-scripts
+# only `package.json` + the lockfile + workspace file are. We regenerate
+# fumadocs sources explicitly in the builder stage below, where the full
+# tree is available.
+FROM node:22.20.0-bookworm-slim AS deps
+WORKDIR /app
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable && corepack prepare pnpm@11.7.0 --activate
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Build Next.js
 FROM base AS builder
@@ -36,9 +42,9 @@ ENV POSTHOG_CLI_HOST=$POSTHOG_CLI_HOST
 
 # `fumadocs-mdx`'s `lastModified` plugin shells out to `git log` for every
 # MDX page (see source.config.ts). `curl` installs `posthog-cli` for the
-# guarded source-map step below. The base `oven/bun:1` image is Debian slim
-# and ships without either, so install them here. Builder-stage only -- the
-# `runner` stage below does not inherit this layer.
+# guarded source-map step below. The pinned `oven/bun:1.4.0` image is
+# Debian slim and ships without either, so install them here.
+# Builder-stage only -- the `runner` stage below does not inherit this layer.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git curl \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Docker on `main` has been red since tonight's merges (#280, #281, #282). Both matrix jobs die in ~4s at the `deps` stage:

`bun install --frozen-lockfile --ignore-scripts` exit 1

Latest failure: https://github.com/riffado/riffado/actions/runs/33015173260

## Cause

`FROM oven/bun:1` floated to bun 1.4.0. That installer migrates `pnpm-lock.yaml` to a bun lockfile and then `--frozen-lockfile` refuses the rewrite:

```
bun install v1.4.0
migrated lockfile from pnpm-lock.yaml
error: lockfile had changes, but lockfile is frozen
```

Hosted CI (`pnpm 11.7.0`, `pnpm install --frozen-lockfile`) stayed green because it never used bun for install. Tonight's PRs did not touch `package.json` or `pnpm-lock.yaml`. Last green Docker on main was #276 (`2527caed`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Relates to #280, #281, #282 (Docker workflow on those merges; no product change)

## Changes Made

- Deps stage now installs with pnpm 11.7.0 via corepack on `node:22.20.0-bookworm-slim`, same pins as `.github/workflows/ci.yml`
- `pnpm install --frozen-lockfile --ignore-scripts` (ignore-scripts still required: fumadocs-mdx postinstall needs the full tree)
- COPY now includes `pnpm-workspace.yaml`
- Runtime/build image stays bun; pin `oven/bun:1.4.0` so a floating `:1` tag cannot break the build again
- No version bump, no release, no changelog (Dockerfile-only deploy-surface fix)

## Testing

Verified in the agent VM, not just GHA pnpm CI:

```
sudo docker build --platform linux/amd64 --progress=plain -t riffado-docker-fix:local .
```

Result: exit 0, image `riffado-docker-fix:local` (749MB).

- `pnpm install --frozen-lockfile --ignore-scripts` — lockfile up to date, done in 6.7s on pnpm 11.7.0
- `bunx fumadocs-mdx source.config.ts src/.source` — ok
- `bun run build` — compiled successfully in 16.8s, full Next.js route table
- `bun build` of `migrate-idempotent.js` and `encrypt-backfill.js` — ok
- runner stage exported

GHA Docker still only runs on push to main/tags. Do not merge from this agent.

## Checklist

- [x] Dockerfile-only; no product behavior change
- [x] Local `docker build --platform linux/amd64` past install into `bun run build`

## Additional Notes

Do not merge. Do not tag a release.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ada6a44d-1f30-4c0d-a21e-f5b31b557e5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ada6a44d-1f30-4c0d-a21e-f5b31b557e5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Docker build, which was red because `oven/bun:1` floated to bun 1.4.0, migrated `pnpm-lock.yaml`, and then failed `--frozen-lockfile` on the change. The deps stage now installs with pnpm 11.7.0 on `node:22.20.0-bookworm-slim` using the same pins as hosted CI, and also copies `pnpm-workspace.yaml`; build and runner stages stay on bun, now pinned to `oven/bun:1.4.0` so the floating tag can't break the build again. No product behavior change, version bump, or release involved.

<sup>Written for commit f4e271f651d1d72e86ddf4ce8d554c7574f06ee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

