### PR TITLE
fix(transcription): dedup concurrent transcribeRecording calls per recording

### DIFF
--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -229,7 +229,30 @@ export interface TranscribeResult {
     detectedLanguage?: string | null;
 }
 
+// Per-recording in-flight dedup within one process. First caller wins
+// (including force/providerId/model). Cross-process is out of scope.
+const inFlightTranscriptions = new Map<string, Promise<TranscribeResult>>();
+
 export async function transcribeRecording(
+    userId: string,
+    recordingId: string,
+    opts: TranscribeOptions = {},
+): Promise<TranscribeResult> {
+    const key = `${userId}:${recordingId}`;
+    const inFlight = inFlightTranscriptions.get(key);
+    if (inFlight) {
+        return inFlight;
+    }
+    const work = transcribeRecordingInner(userId, recordingId, opts);
+    inFlightTranscriptions.set(key, work);
+    try {
+        return await work;
+    } finally {
+        inFlightTranscriptions.delete(key);
+    }
+}
+
+async function transcribeRecordingInner(
     userId: string,
     recordingId: string,
     opts: TranscribeOptions = {},

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -229,8 +229,8 @@ export interface TranscribeResult {
     detectedLanguage?: string | null;
 }
 
-// Per-recording in-flight dedup within one process. First caller wins
-// (including force/providerId/model). Cross-process is out of scope.
+// Per-recording in-flight dedup within one process. Force and non-force
+// are partitioned so Retry cannot inherit an auto-transcribe skip.
 const inFlightTranscriptions = new Map<string, Promise<TranscribeResult>>();
 
 export async function transcribeRecording(
@@ -238,7 +238,7 @@ export async function transcribeRecording(
     recordingId: string,
     opts: TranscribeOptions = {},
 ): Promise<TranscribeResult> {
-    const key = `${userId}:${recordingId}`;
+    const key = `${userId}:${recordingId}:${opts.force ? "force" : "auto"}`;
     const inFlight = inFlightTranscriptions.get(key);
     if (inFlight) {
         return inFlight;

--- a/src/tests/transcribe-inflight-dedup.test.ts
+++ b/src/tests/transcribe-inflight-dedup.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Pins same-process in-flight dedup in `transcribeRecording`.
+ *
+ * Two same-worker paths can race the provider for one recording:
+ *   1. Manual `POST /api/recordings/[id]/transcribe` (`force: true`).
+ *      Retry double-click fans out two concurrent provider calls.
+ *   2. Post-sync auto-transcribe (`queueTranscriptions` in
+ *      `sync-recordings.ts`) can land mid-Retry on the same worker.
+ *
+ * #282's `claimAutoTranscribeIds` only skips ids already in the
+ * auto-transcribe set. It does not cover Retry double-click or Retry
+ * overlapping a sync pass. This map is complementary, not a substitute.
+ *
+ * Concurrent calls for the same (userId, recordingId) share one
+ * in-flight promise. Mirrors `inFlightSyncs` in `sync-recordings.ts`.
+ * Multi-process hosted correctness is out of scope.
+ */
+
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        transaction: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/encryption", () => ({
+    decrypt: vi.fn().mockReturnValue("fake-api-key"),
+    encrypt: vi.fn((plaintext: string) => `encrypted:${plaintext}`),
+}));
+
+vi.mock("@/lib/encryption/fields", async () => {
+    const actual = await vi.importActual<
+        typeof import("@/lib/encryption/fields")
+    >("@/lib/encryption/fields");
+    return {
+        ...actual,
+        decryptText: vi.fn((value: string) => value),
+        encryptText: vi.fn((value: string) => `enc:${value}`),
+    };
+});
+
+vi.mock("@/lib/storage/factory", () => ({
+    createUserStorageProvider: vi.fn().mockResolvedValue({
+        downloadFile: vi.fn().mockResolvedValue(Buffer.from("fake-mp3-bytes")),
+    }),
+}));
+
+const audioCreate = vi.fn();
+const chatCreate = vi.fn();
+
+vi.mock("openai", () => {
+    const MockOpenAI = vi.fn(() => ({
+        audio: { transcriptions: { create: audioCreate } },
+        chat: { completions: { create: chatCreate } },
+    }));
+    return { OpenAI: MockOpenAI };
+});
+
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/entitlements", () => ({
+    isHostedLockedOut: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        WHISPER_MAX_BYTES: 24 * 1024 * 1024,
+        WHISPER_COMPRESS_BITRATE_KBPS: 12,
+        WHISPER_REQUEST_TIMEOUT_MS: 60 * 60 * 1000,
+    },
+}));
+
+vi.mock("@/lib/hosted/transcription/mynah", () => ({
+    isMynahConfigured: vi.fn().mockReturnValue(false),
+    transcribeViaMynah: vi.fn(),
+}));
+
+vi.mock("@/lib/ai/generate-title", () => ({
+    generateTitleFromTranscription: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/plaud/client-factory", () => ({
+    createPlaudClient: vi.fn(),
+}));
+
+import { OpenAI } from "openai";
+import { db } from "@/db";
+import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
+
+const USER_ID = "user-dedup";
+
+/**
+ * Stage one full transcribe attempt's worth of DB reads on `db.select`
+ * and `db.transaction`. Matches the current `transcribeRecordingInner`
+ * select order: recording, existing riffado transcript, default
+ * credentials, user settings. Each inner call consumes one staging.
+ * Staging twice covers a non-deduped fanout and is harmless overshoot
+ * when dedup engages.
+ */
+function stageOneAttempt(recordingId: string, userId: string = USER_ID) {
+    const recordingRow = {
+        id: recordingId,
+        userId,
+        plaudFileId: `plaud-${recordingId}`,
+        filename: "Some Recording",
+        storagePath: `${recordingId}.mp3`,
+        deletedAt: null,
+    };
+    const credsRow = {
+        id: "creds-1",
+        provider: "OpenAI",
+        apiKey: "encrypted-key",
+        baseUrl: null,
+        defaultModel: "whisper-1",
+    };
+
+    (db.select as Mock)
+        .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([recordingRow]),
+                }),
+            }),
+        })
+        .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([]),
+                }),
+            }),
+        })
+        .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([credsRow]),
+                }),
+            }),
+        })
+        .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+                where: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockResolvedValue([
+                        {
+                            autoGenerateTitle: false,
+                            syncTitleToPlaud: false,
+                            transcriptionQuality: "balanced",
+                            defaultTranscriptionLanguage: null,
+                        },
+                    ]),
+                }),
+            }),
+        });
+
+    const tx = {
+        select: vi
+            .fn()
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        for: vi.fn().mockReturnValue({
+                            limit: vi
+                                .fn()
+                                .mockResolvedValue([{ deletedAt: null }]),
+                        }),
+                    }),
+                }),
+            })
+            .mockReturnValueOnce({
+                from: vi.fn().mockReturnValue({
+                    where: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([]),
+                    }),
+                }),
+            }),
+        insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockResolvedValue(undefined),
+        }),
+        update: vi.fn().mockReturnValue({
+            set: vi.fn().mockReturnValue({
+                where: vi.fn().mockResolvedValue(undefined),
+            }),
+        }),
+    };
+    (db.transaction as Mock).mockImplementationOnce(
+        async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx),
+    );
+    (db.delete as Mock).mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+    });
+}
+
+describe("transcribeRecording — in-flight dedup", () => {
+    beforeEach(() => {
+        (db.select as Mock).mockReset();
+        (db.transaction as Mock).mockReset();
+        (db.delete as Mock).mockReset();
+        audioCreate.mockReset();
+        chatCreate.mockReset();
+        // biome-ignore lint/complexity/useArrowFunction: mock must be constructable
+        (OpenAI as unknown as Mock).mockImplementation(function () {
+            return {
+                audio: { transcriptions: { create: audioCreate } },
+                chat: { completions: { create: chatCreate } },
+            };
+        });
+    });
+
+    it("collapses two concurrent calls for the same recording into a single provider call (shared result, single audioCreate)", async () => {
+        audioCreate.mockResolvedValue({
+            text: "shared transcript",
+            language: "en",
+        });
+        stageOneAttempt("rec-shared");
+        stageOneAttempt("rec-shared");
+
+        const callA = transcribeRecording(USER_ID, "rec-shared", {
+            force: true,
+        });
+        const callB = transcribeRecording(USER_ID, "rec-shared", {
+            force: true,
+        });
+
+        const [resA, resB] = await Promise.all([callA, callB]);
+
+        expect(resA.success).toBe(true);
+        expect(resB.success).toBe(true);
+        expect(resA).toBe(resB);
+        expect(audioCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("shares the in-flight promise when Retry (force) overlaps a sync auto-transcribe", async () => {
+        audioCreate.mockResolvedValue({
+            text: "overlap transcript",
+            language: "en",
+        });
+        stageOneAttempt("rec-overlap");
+        stageOneAttempt("rec-overlap");
+
+        const retry = transcribeRecording(USER_ID, "rec-overlap", {
+            force: true,
+            trigger: "manual",
+        });
+        const auto = transcribeRecording(USER_ID, "rec-overlap", {
+            trigger: "sync",
+        });
+
+        const [resRetry, resAuto] = await Promise.all([retry, auto]);
+
+        expect(resRetry.success).toBe(true);
+        expect(resAuto.success).toBe(true);
+        expect(resRetry).toBe(resAuto);
+        expect(audioCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT dedup across distinct recordingIds (each gets its own provider call)", async () => {
+        audioCreate.mockResolvedValue({
+            text: "transcript",
+            language: "en",
+        });
+        stageOneAttempt("rec-a");
+        const resA = await transcribeRecording(USER_ID, "rec-a", {
+            force: true,
+        });
+        stageOneAttempt("rec-b");
+        const resB = await transcribeRecording(USER_ID, "rec-b", {
+            force: true,
+        });
+
+        expect(resA.success).toBe(true);
+        expect(resB.success).toBe(true);
+        expect(audioCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it("does NOT dedup across distinct users even with the same recordingId (key namespaces by userId)", async () => {
+        audioCreate.mockResolvedValue({
+            text: "transcript",
+            language: "en",
+        });
+        stageOneAttempt("rec-shared-id", "user-a");
+        const resA = await transcribeRecording("user-a", "rec-shared-id", {
+            force: true,
+        });
+        stageOneAttempt("rec-shared-id", "user-b");
+        const resB = await transcribeRecording("user-b", "rec-shared-id", {
+            force: true,
+        });
+
+        expect(resA.success).toBe(true);
+        expect(resB.success).toBe(true);
+        expect(audioCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears the in-flight cache after the promise settles so a follow-up call re-runs", async () => {
+        audioCreate.mockResolvedValue({
+            text: "first call",
+            language: "en",
+        });
+        stageOneAttempt("rec-followup");
+        const first = await transcribeRecording(USER_ID, "rec-followup", {
+            force: true,
+        });
+        expect(first.success).toBe(true);
+        expect(audioCreate).toHaveBeenCalledTimes(1);
+
+        audioCreate.mockResolvedValue({
+            text: "second call",
+            language: "en",
+        });
+        stageOneAttempt("rec-followup");
+        const second = await transcribeRecording(USER_ID, "rec-followup", {
+            force: true,
+        });
+        expect(second.success).toBe(true);
+        expect(audioCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it("propagates errors to all concurrent waiters and still clears the cache for a fresh retry", async () => {
+        audioCreate.mockRejectedValueOnce(new Error("upstream 500"));
+        stageOneAttempt("rec-error");
+        stageOneAttempt("rec-error");
+
+        const callA = transcribeRecording(USER_ID, "rec-error", {
+            force: true,
+        });
+        const callB = transcribeRecording(USER_ID, "rec-error", {
+            force: true,
+        });
+
+        const [resA, resB] = await Promise.all([callA, callB]);
+        expect(resA.success).toBe(false);
+        expect(resB.success).toBe(false);
+        expect(resA.errorCode).toBe("TRANSCRIPTION_FAILED");
+        expect(resB.errorCode).toBe("TRANSCRIPTION_FAILED");
+        expect(resA).toBe(resB);
+        expect(audioCreate).toHaveBeenCalledTimes(1);
+
+        audioCreate.mockResolvedValueOnce({
+            text: "succeeded on retry",
+            language: "en",
+        });
+        stageOneAttempt("rec-error");
+        const retry = await transcribeRecording(USER_ID, "rec-error", {
+            force: true,
+        });
+        expect(retry.success).toBe(true);
+        expect(audioCreate).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/tests/transcribe-inflight-dedup.test.ts
+++ b/src/tests/transcribe-inflight-dedup.test.ts
@@ -8,11 +8,12 @@
  *      `sync-recordings.ts`) can land mid-Retry on the same worker.
  *
  * #282's `claimAutoTranscribeIds` only skips ids already in the
- * auto-transcribe set. It does not cover Retry double-click or Retry
- * overlapping a sync pass. This map is complementary, not a substitute.
+ * auto-transcribe set. It does not cover Retry double-click.
+ * This map is complementary, not a substitute.
  *
- * Concurrent calls for the same (userId, recordingId) share one
- * in-flight promise. Mirrors `inFlightSyncs` in `sync-recordings.ts`.
+ * Equivalent-option calls for the same (userId, recordingId, force)
+ * share one in-flight promise. Force is partitioned from non-force so
+ * Retry cannot inherit an auto-transcribe idempotent skip.
  * Multi-process hosted correctness is out of scope.
  */
 
@@ -92,93 +93,63 @@ vi.mock("@/lib/plaud/client-factory", () => ({
 
 import { OpenAI } from "openai";
 import { db } from "@/db";
+import { isHostedLockedOut } from "@/lib/entitlements";
 import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
 
 const USER_ID = "user-dedup";
 
+function createDeferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
 /**
- * Stage one full transcribe attempt's worth of DB reads on `db.select`
- * and `db.transaction`. Matches the current `transcribeRecordingInner`
- * select order: recording, existing riffado transcript, default
- * credentials, user settings. Each inner call consumes one staging.
- * Staging twice covers a non-deduped fanout and is harmless overshoot
- * when dedup engages.
+ * Concurrent-safe stub: every `db.select` returns the same union row so
+ * interleaved inners do not consume a FIFO Once-queue out of order.
+ * `existingText` makes the idempotent skip fire for non-force callers.
  */
-function stageOneAttempt(recordingId: string, userId: string = USER_ID) {
-    const recordingRow = {
-        id: recordingId,
-        userId,
-        plaudFileId: `plaud-${recordingId}`,
+function installSelectStub(opts: { existingText?: string } = {}) {
+    const row = {
+        id: "row-1",
+        userId: USER_ID,
+        plaudFileId: "plaud-1",
         filename: "Some Recording",
-        storagePath: `${recordingId}.mp3`,
+        storagePath: "rec.mp3",
         deletedAt: null,
-    };
-    const credsRow = {
-        id: "creds-1",
+        text: opts.existingText,
+        detectedLanguage: opts.existingText ? "en" : null,
         provider: "OpenAI",
         apiKey: "encrypted-key",
         baseUrl: null,
         defaultModel: "whisper-1",
+        autoGenerateTitle: false,
+        syncTitleToPlaud: false,
+        transcriptionQuality: "balanced",
+        defaultTranscriptionLanguage: null,
     };
 
-    (db.select as Mock)
-        .mockReturnValueOnce({
-            from: vi.fn().mockReturnValue({
-                where: vi.fn().mockReturnValue({
-                    limit: vi.fn().mockResolvedValue([recordingRow]),
-                }),
+    (db.select as Mock).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([row]),
             }),
-        })
-        .mockReturnValueOnce({
+        }),
+    });
+
+    const tx = {
+        select: vi.fn().mockReturnValue({
             from: vi.fn().mockReturnValue({
                 where: vi.fn().mockReturnValue({
+                    for: vi.fn().mockReturnValue({
+                        limit: vi.fn().mockResolvedValue([{ deletedAt: null }]),
+                    }),
                     limit: vi.fn().mockResolvedValue([]),
                 }),
             }),
-        })
-        .mockReturnValueOnce({
-            from: vi.fn().mockReturnValue({
-                where: vi.fn().mockReturnValue({
-                    limit: vi.fn().mockResolvedValue([credsRow]),
-                }),
-            }),
-        })
-        .mockReturnValueOnce({
-            from: vi.fn().mockReturnValue({
-                where: vi.fn().mockReturnValue({
-                    limit: vi.fn().mockResolvedValue([
-                        {
-                            autoGenerateTitle: false,
-                            syncTitleToPlaud: false,
-                            transcriptionQuality: "balanced",
-                            defaultTranscriptionLanguage: null,
-                        },
-                    ]),
-                }),
-            }),
-        });
-
-    const tx = {
-        select: vi
-            .fn()
-            .mockReturnValueOnce({
-                from: vi.fn().mockReturnValue({
-                    where: vi.fn().mockReturnValue({
-                        for: vi.fn().mockReturnValue({
-                            limit: vi
-                                .fn()
-                                .mockResolvedValue([{ deletedAt: null }]),
-                        }),
-                    }),
-                }),
-            })
-            .mockReturnValueOnce({
-                from: vi.fn().mockReturnValue({
-                    where: vi.fn().mockReturnValue({
-                        limit: vi.fn().mockResolvedValue([]),
-                    }),
-                }),
-            }),
+        }),
         insert: vi.fn().mockReturnValue({
             values: vi.fn().mockResolvedValue(undefined),
         }),
@@ -188,7 +159,7 @@ function stageOneAttempt(recordingId: string, userId: string = USER_ID) {
             }),
         }),
     };
-    (db.transaction as Mock).mockImplementationOnce(
+    (db.transaction as Mock).mockImplementation(
         async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx),
     );
     (db.delete as Mock).mockReturnValue({
@@ -201,6 +172,8 @@ describe("transcribeRecording — in-flight dedup", () => {
         (db.select as Mock).mockReset();
         (db.transaction as Mock).mockReset();
         (db.delete as Mock).mockReset();
+        (isHostedLockedOut as Mock).mockReset();
+        (isHostedLockedOut as Mock).mockResolvedValue(false);
         audioCreate.mockReset();
         chatCreate.mockReset();
         // biome-ignore lint/complexity/useArrowFunction: mock must be constructable
@@ -217,8 +190,7 @@ describe("transcribeRecording — in-flight dedup", () => {
             text: "shared transcript",
             language: "en",
         });
-        stageOneAttempt("rec-shared");
-        stageOneAttempt("rec-shared");
+        installSelectStub();
 
         const callA = transcribeRecording(USER_ID, "rec-shared", {
             force: true,
@@ -235,43 +207,54 @@ describe("transcribeRecording — in-flight dedup", () => {
         expect(audioCreate).toHaveBeenCalledTimes(1);
     });
 
-    it("shares the in-flight promise when Retry (force) overlaps a sync auto-transcribe", async () => {
+    it("does not let a force Retry inherit an in-flight auto-transcribe skip", async () => {
+        const lockout = createDeferred<boolean>();
+        (isHostedLockedOut as Mock)
+            .mockImplementationOnce(() => lockout.promise)
+            .mockResolvedValue(false);
         audioCreate.mockResolvedValue({
-            text: "overlap transcript",
+            text: "forced retranscription",
             language: "en",
         });
-        stageOneAttempt("rec-overlap");
-        stageOneAttempt("rec-overlap");
+        installSelectStub({ existingText: "already transcribed" });
 
-        const retry = transcribeRecording(USER_ID, "rec-overlap", {
+        const auto = transcribeRecording(USER_ID, "rec-skip", {
+            trigger: "sync",
+        });
+        await Promise.resolve();
+
+        const retry = transcribeRecording(USER_ID, "rec-skip", {
             force: true,
             trigger: "manual",
         });
-        const auto = transcribeRecording(USER_ID, "rec-overlap", {
-            trigger: "sync",
-        });
+        await vi.waitFor(() => expect(audioCreate).toHaveBeenCalledTimes(1));
 
-        const [resRetry, resAuto] = await Promise.all([retry, auto]);
+        lockout.resolve(false);
+        const [autoRes, retryRes] = await Promise.all([auto, retry]);
 
-        expect(resRetry.success).toBe(true);
-        expect(resAuto.success).toBe(true);
-        expect(resRetry).toBe(resAuto);
+        expect(autoRes.success).toBe(true);
+        expect(autoRes.text).toBe("already transcribed");
+        expect(retryRes.success).toBe(true);
+        expect(retryRes.text).toBe("forced retranscription");
+        expect(retryRes).not.toBe(autoRes);
         expect(audioCreate).toHaveBeenCalledTimes(1);
     });
 
     it("does NOT dedup across distinct recordingIds (each gets its own provider call)", async () => {
-        audioCreate.mockResolvedValue({
-            text: "transcript",
-            language: "en",
-        });
-        stageOneAttempt("rec-a");
-        const resA = await transcribeRecording(USER_ID, "rec-a", {
+        const gate = createDeferred<{ text: string; language: string }>();
+        audioCreate.mockReturnValue(gate.promise);
+        installSelectStub();
+
+        const callA = transcribeRecording(USER_ID, "rec-a", {
             force: true,
         });
-        stageOneAttempt("rec-b");
-        const resB = await transcribeRecording(USER_ID, "rec-b", {
+        const callB = transcribeRecording(USER_ID, "rec-b", {
             force: true,
         });
+        await vi.waitFor(() => expect(audioCreate).toHaveBeenCalledTimes(2));
+
+        gate.resolve({ text: "transcript", language: "en" });
+        const [resA, resB] = await Promise.all([callA, callB]);
 
         expect(resA.success).toBe(true);
         expect(resB.success).toBe(true);
@@ -279,18 +262,20 @@ describe("transcribeRecording — in-flight dedup", () => {
     });
 
     it("does NOT dedup across distinct users even with the same recordingId (key namespaces by userId)", async () => {
-        audioCreate.mockResolvedValue({
-            text: "transcript",
-            language: "en",
-        });
-        stageOneAttempt("rec-shared-id", "user-a");
-        const resA = await transcribeRecording("user-a", "rec-shared-id", {
+        const gate = createDeferred<{ text: string; language: string }>();
+        audioCreate.mockReturnValue(gate.promise);
+        installSelectStub();
+
+        const callA = transcribeRecording("user-a", "rec-shared-id", {
             force: true,
         });
-        stageOneAttempt("rec-shared-id", "user-b");
-        const resB = await transcribeRecording("user-b", "rec-shared-id", {
+        const callB = transcribeRecording("user-b", "rec-shared-id", {
             force: true,
         });
+        await vi.waitFor(() => expect(audioCreate).toHaveBeenCalledTimes(2));
+
+        gate.resolve({ text: "transcript", language: "en" });
+        const [resA, resB] = await Promise.all([callA, callB]);
 
         expect(resA.success).toBe(true);
         expect(resB.success).toBe(true);
@@ -302,7 +287,7 @@ describe("transcribeRecording — in-flight dedup", () => {
             text: "first call",
             language: "en",
         });
-        stageOneAttempt("rec-followup");
+        installSelectStub();
         const first = await transcribeRecording(USER_ID, "rec-followup", {
             force: true,
         });
@@ -313,7 +298,6 @@ describe("transcribeRecording — in-flight dedup", () => {
             text: "second call",
             language: "en",
         });
-        stageOneAttempt("rec-followup");
         const second = await transcribeRecording(USER_ID, "rec-followup", {
             force: true,
         });
@@ -323,8 +307,7 @@ describe("transcribeRecording — in-flight dedup", () => {
 
     it("propagates errors to all concurrent waiters and still clears the cache for a fresh retry", async () => {
         audioCreate.mockRejectedValueOnce(new Error("upstream 500"));
-        stageOneAttempt("rec-error");
-        stageOneAttempt("rec-error");
+        installSelectStub();
 
         const callA = transcribeRecording(USER_ID, "rec-error", {
             force: true,
@@ -345,7 +328,6 @@ describe("transcribeRecording — in-flight dedup", () => {
             text: "succeeded on retry",
             language: "en",
         });
-        stageOneAttempt("rec-error");
         const retry = await transcribeRecording(USER_ID, "rec-error", {
             force: true,
         });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Scope lock

Same-process `transcribeRecording` dedup only: an in-flight `Map` keyed by `(userId, recordingId, force|auto)`. Equivalent-option calls share one promise. Force is partitioned from non-force so Retry cannot inherit an auto-transcribe skip.

Not in this PR:

- #91 (Postgres-backed transcription worker, SKIP LOCKED, status machine, Cancel, enqueue-from-sync)
- Multi-process / hosted locking
- Worker rewrite
- Replacing or editing #282 (`claimAutoTranscribeIds` / retry rotation)

#282 stays complementary. This map covers Retry double-click. #282 still owns the auto-transcribe claim set.

PRs only. Do not merge.

## Description

Reimplements stale [#205](https://github.com/riffado/riffado/pull/205) on current `main` (`e3d885c`, after #279–#284). Does not push to the fork. Does not merge #205.

Two same-process paths can still double-fire the transcription provider for one recording:

1. **Retry double-click** — `POST /api/recordings/[id]/transcribe` always passes `force: true`.
2. **Retry overlapping post-sync auto-transcribe** — `queueTranscriptions` can land mid-Retry on the same worker.

Without coalescing, both pay full provider latency. A long recording can sit near the request timeout; the slower call fails even though the first would have succeeded.

## Review fixes on this revision

1. **Greptile P1:** in-flight key is `${userId}:${recordingId}:${force ? "force" : "auto"}`. A `{ force: true }` Retry no longer joins a non-force auto-transcribe and inherits its idempotent skip. Regression: auto in-flight first (existing transcript), then force Retry, provider is called for the force run.
2. **Cubic P2:** distinct-`recordingId` and distinct-`userId` tests now hold `audioCreate` on a deferred and launch both calls before either settles, then assert two provider calls.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Relates to #205
Relates to #282

This PR **supersedes** [#205](https://github.com/riffado/riffado/pull/205). **#282 is complementary, not a substitute.**

## Changes Made

- Module-level `Map` on `transcribeRecording`, mirroring `inFlightSyncs`.
- Force vs non-force partitioned. Equivalent-option calls still share.
- Inner body is current `main` `transcribeRecording` unchanged. No sync/auto-transcribe-state edits.

## Testing

- Concurrent same recording + same force: one provider call, same result object
- Auto in-flight first, then force Retry: provider called for the force run; results are distinct
- Distinct `recordingId`s / `userId`s, genuinely concurrent: two provider calls
- Cache clears after settle; errors fan out and retry works
- #101 diarize-chunking and #282 retry rotation untouched and still pass

Local: 928 passed, 10 skipped. Type-check clean.

## Checklist

- [x] Style (`pnpm format-and-lint`)
- [x] Tests added
- [x] Type checking (`pnpm type-check`)
- [x] New and existing unit tests pass locally (`pnpm test`)

## Additional Notes

Two-file diff: wrapper + tests. No Dockerfile, billing, schema, route, worker, or sync-queue changes.

## For Reviewers

- Key partition in `src/lib/transcription/transcribe-recording.ts`.
- Confirm #282 is untouched.
- Reject any review that pulls this toward #91.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-baefbd00-364e-4731-8037-93b6289e5223?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baefbd00-364e-4731-8037-93b6289e5223&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate transcription provider calls for the same recording, so concurrent Retry or sync-triggered transcribes no longer double-pay provider latency or race the transcriptions upsert.

- Concurrent calls for one `(userId, recordingId, force|auto)` share a single in-flight promise; the first caller's `providerId` and `model` win.
- Force calls are partitioned from non-force calls, so a Retry can't inherit an auto-transcribe's idempotent skip.
- The dedup cache clears once the call settles, so a later call starts a fresh run.
- Complements #282's `claimAutoTranscribeIds`, which only skips ids already in the auto-transcribe set and does not cover Retry double-clicks.
- Supersedes stale #205 reimplemented on current `main`.

<sup>Written for commit 648ca418ea6a210b2fad528e18896b0a4d54e8a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

