### PR TITLE
fix(sync): pagination early-exit starves old recordings of content backfill

### DIFF
--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -226,9 +226,7 @@ async function processRecording(
             existingRecording &&
             existingRecording.plaudVersion === versionKey
         ) {
-            // Audio is current, but Plaud may have finished a transcript or
-            // summary without bumping version_ms. Keep those rows eligible
-            // for content backfill (#274). Tombstones stay skipped.
+            // Version match skips the audio download, not content backfill (#274).
             if (context.importPlaudContent && !existingRecording.deletedAt) {
                 return {
                     status: "skipped",
@@ -639,11 +637,8 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
             } else if (plaudRecordings.length < SYNC_CONFIG.PAGE_SIZE) {
                 hasMore = false;
             } else if (
-                // Two no-change pages imply older audio is unchanged
-                // (list is edit_time desc). That must not apply while
-                // import is on: Plaud can attach transcript/summary to
-                // older files without a version bump, and those sit
-                // past the first two pages (#274).
+                // Import can still need later pages after two no-change
+                // audio pages (#274).
                 !context.importPlaudContent &&
                 result.newRecordings === 0 &&
                 result.updatedRecordings === 0
@@ -853,10 +848,14 @@ async function importPlaudContent(
     for (const candidate of candidates) {
         if (tokenDead) break;
         try {
-            // Gap-fill checks first so a version-unchanged backfill walk
-            // (#274) does not call getFileDetail for rows already imported.
-            let needsTranscript = false;
-            if (candidate.isTrans) {
+            const detail = await plaudClient.getFileDetail(
+                candidate.plaudFileId,
+            );
+            const { transcript, summary } = selectContentItems(detail);
+
+            // --- Transcript (coexists with the user's own; gap-fill only) ---
+            const transcriptLink = transcript?.data_link;
+            if (candidate.isTrans && isReady(transcript) && transcriptLink) {
                 const [existing] = await db
                     .select({ id: transcriptions.id })
                     .from(transcriptions)
@@ -877,12 +876,34 @@ async function importPlaudContent(
                     // 'plaud_only' still suppresses re-transcription.
                     transcriptImported.add(candidate.recordingId);
                 } else {
-                    needsTranscript = true;
+                    const parsed = parseTranscript(
+                        await plaudClient.fetchContentLink(transcriptLink),
+                    );
+                    if (parsed.text.trim()) {
+                        const { committed } = await upsertTranscription({
+                            userId: context.userId,
+                            recordingId: candidate.recordingId,
+                            text: parsed.text,
+                            detectedLanguage: parsed.language,
+                            source: "plaud",
+                            provider: "plaud",
+                            model: "plaud-native",
+                        });
+                        if (committed) {
+                            transcriptImported.add(candidate.recordingId);
+                            await emitEvent(
+                                "transcription.completed",
+                                context.userId,
+                                candidate.recordingId,
+                            );
+                        }
+                    }
                 }
             }
 
-            let needsSummary = false;
-            if (candidate.isSummary) {
+            // --- Summary (single per recording; gap-fill only) ---
+            const summaryLink = summary?.data_link;
+            if (candidate.isSummary && isReady(summary) && summaryLink) {
                 const [existing] = await db
                     .select({ id: aiEnhancements.id })
                     .from(aiEnhancements)
@@ -896,63 +917,27 @@ async function importPlaudContent(
                         ),
                     )
                     .limit(1);
-                if (!existing) needsSummary = true;
-            }
 
-            if (!needsTranscript && !needsSummary) continue;
-
-            const detail = await plaudClient.getFileDetail(
-                candidate.plaudFileId,
-            );
-            const { transcript, summary } = selectContentItems(detail);
-
-            // --- Transcript (coexists with the user's own; gap-fill only) ---
-            const transcriptLink = transcript?.data_link;
-            if (needsTranscript && isReady(transcript) && transcriptLink) {
-                const parsed = parseTranscript(
-                    await plaudClient.fetchContentLink(transcriptLink),
-                );
-                if (parsed.text.trim()) {
-                    const { committed } = await upsertTranscription({
-                        userId: context.userId,
-                        recordingId: candidate.recordingId,
-                        text: parsed.text,
-                        detectedLanguage: parsed.language,
-                        source: "plaud",
-                        provider: "plaud",
-                        model: "plaud-native",
-                    });
-                    if (committed) {
-                        transcriptImported.add(candidate.recordingId);
-                        await emitEvent(
-                            "transcription.completed",
-                            context.userId,
-                            candidate.recordingId,
-                        );
+                if (!existing) {
+                    // Prefer the inline copy (no S3 round-trip, no presign
+                    // expiry, #203); fall back to the presigned link.
+                    const inline = findInlineContent(detail, summary?.data_id);
+                    const parsed = parseSummary(
+                        inline ??
+                            (await plaudClient.fetchContentLink(summaryLink)),
+                    );
+                    if (parsed.summary.trim()) {
+                        await upsertEnhancement({
+                            userId: context.userId,
+                            recordingId: candidate.recordingId,
+                            summary: parsed.summary,
+                            keyPoints: parsed.keyPoints,
+                            actionItems: parsed.actionItems,
+                            source: "plaud",
+                            provider: "plaud",
+                            model: "plaud-native",
+                        });
                     }
-                }
-            }
-
-            // --- Summary (single per recording; gap-fill only) ---
-            const summaryLink = summary?.data_link;
-            if (needsSummary && isReady(summary) && summaryLink) {
-                // Prefer the inline copy (no S3 round-trip, no presign
-                // expiry, #203); fall back to the presigned link.
-                const inline = findInlineContent(detail, summary?.data_id);
-                const parsed = parseSummary(
-                    inline ?? (await plaudClient.fetchContentLink(summaryLink)),
-                );
-                if (parsed.summary.trim()) {
-                    await upsertEnhancement({
-                        userId: context.userId,
-                        recordingId: candidate.recordingId,
-                        summary: parsed.summary,
-                        keyPoints: parsed.keyPoints,
-                        actionItems: parsed.actionItems,
-                        source: "plaud",
-                        provider: "plaud",
-                        model: "plaud-native",
-                    });
                 }
             }
         } catch (error) {

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -236,6 +236,7 @@ async function hasUnseenPlaudContentGaps(
     const conditions = [
         eq(recordings.userId, userId),
         isNull(recordings.deletedAt),
+        ne(recordings.deviceSn, "local"),
         or(isNull(transcriptions.id), isNull(aiEnhancements.id)),
     ];
     if (seenRecordingIds.size > 0) {

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -1,4 +1,4 @@
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, isNull, ne, notInArray } from "drizzle-orm";
 import { db } from "@/db";
 import {
     aiEnhancements,
@@ -184,6 +184,81 @@ function buildImportCandidate(
     };
 }
 
+async function loadPlaudContentGaps(
+    userId: string,
+    recordingId: string,
+    flags: { isTrans: boolean; isSummary: boolean },
+): Promise<{
+    needsTranscript: boolean;
+    needsSummary: boolean;
+    hasPlaudTranscript: boolean;
+}> {
+    let needsTranscript = false;
+    let hasPlaudTranscript = false;
+    if (flags.isTrans) {
+        const [existing] = await db
+            .select({ id: transcriptions.id })
+            .from(transcriptions)
+            .where(
+                and(
+                    eq(transcriptions.recordingId, recordingId),
+                    eq(transcriptions.userId, userId),
+                    eq(transcriptions.source, "plaud"),
+                ),
+            )
+            .limit(1);
+        if (existing) hasPlaudTranscript = true;
+        else needsTranscript = true;
+    }
+
+    let needsSummary = false;
+    if (flags.isSummary) {
+        const [existing] = await db
+            .select({ id: aiEnhancements.id })
+            .from(aiEnhancements)
+            .where(
+                and(
+                    eq(aiEnhancements.recordingId, recordingId),
+                    eq(aiEnhancements.userId, userId),
+                ),
+            )
+            .limit(1);
+        if (!existing) needsSummary = true;
+    }
+
+    return { needsTranscript, needsSummary, hasPlaudTranscript };
+}
+
+async function hasUnseenPlaudTranscriptGaps(
+    userId: string,
+    seenRecordingIds: Set<string>,
+): Promise<boolean> {
+    const conditions = [
+        eq(recordings.userId, userId),
+        isNull(recordings.deletedAt),
+        isNull(transcriptions.id),
+    ];
+    if (seenRecordingIds.size > 0) {
+        conditions.push(notInArray(recordings.id, [...seenRecordingIds]));
+    }
+
+    const [row] = await db
+        .select({ id: recordings.id })
+        .from(recordings)
+        .leftJoin(
+            transcriptions,
+            and(
+                eq(transcriptions.recordingId, recordings.id),
+                eq(transcriptions.userId, userId),
+                eq(transcriptions.source, "plaud"),
+            ),
+        )
+        .where(and(...conditions))
+        .limit(1);
+
+    return Boolean(row);
+}
+
 /**
  * Mutable per-sync-run flag. Once a new recording is blocked by the
  * storage cap, every subsequent new recording in the same run is skipped
@@ -200,6 +275,7 @@ async function processRecording(
     plaudClient: Awaited<ReturnType<typeof createPlaudClient>>,
     storage: Awaited<ReturnType<typeof createUserStorageProvider>>,
     capState: CapState,
+    seenRecordingIds: Set<string>,
 ): Promise<{
     status: "new" | "updated" | "skipped" | "error";
     recordingId?: string;
@@ -220,22 +296,36 @@ async function processRecording(
             )
             .limit(1);
 
+        if (existingRecording) seenRecordingIds.add(existingRecording.id);
+
         const versionKey = plaudRecording.version_ms.toString();
 
         if (
             existingRecording &&
             existingRecording.plaudVersion === versionKey
         ) {
-            // Version match skips the audio download, not content backfill (#274).
             if (context.importPlaudContent && !existingRecording.deletedAt) {
-                return {
-                    status: "skipped",
-                    recordingId: existingRecording.id,
-                    importCandidate: buildImportCandidate(
+                const importCandidate = buildImportCandidate(
+                    existingRecording.id,
+                    plaudRecording,
+                );
+                if (importCandidate) {
+                    const gaps = await loadPlaudContentGaps(
+                        context.userId,
                         existingRecording.id,
-                        plaudRecording,
-                    ),
-                };
+                        {
+                            isTrans: importCandidate.isTrans,
+                            isSummary: importCandidate.isSummary,
+                        },
+                    );
+                    if (gaps.needsTranscript || gaps.needsSummary) {
+                        return {
+                            status: "skipped",
+                            recordingId: existingRecording.id,
+                            importCandidate,
+                        };
+                    }
+                }
             }
             return { status: "skipped" };
         }
@@ -362,6 +452,8 @@ async function processRecording(
             .values(recordingData)
             .returning({ id: recordings.id });
 
+        seenRecordingIds.add(newRecording.id);
+
         await emitEvent("recording.synced", context.userId, newRecording.id);
 
         return {
@@ -387,6 +479,7 @@ async function processBatch(
     plaudClient: Awaited<ReturnType<typeof createPlaudClient>>,
     storage: Awaited<ReturnType<typeof createUserStorageProvider>>,
     capState: CapState,
+    seenRecordingIds: Set<string>,
 ): Promise<{
     newCount: number;
     updatedCount: number;
@@ -398,7 +491,14 @@ async function processBatch(
 }> {
     const results = await Promise.allSettled(
         batch.map((rec) =>
-            processRecording(rec, context, plaudClient, storage, capState),
+            processRecording(
+                rec,
+                context,
+                plaudClient,
+                storage,
+                capState,
+                seenRecordingIds,
+            ),
         ),
     );
 
@@ -582,6 +682,7 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
         const allNewRecordingNames: string[] = [];
         const importCandidates: ImportCandidate[] = [];
         const capState: CapState = { blocked: false };
+        const seenRecordingIds = new Set<string>();
 
         let page = 0;
         let hasMore = true;
@@ -603,6 +704,10 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
                 break;
             }
 
+            let pageNew = 0;
+            let pageUpdated = 0;
+            let pageCandidateCount = 0;
+
             for (
                 let i = 0;
                 i < plaudRecordings.length;
@@ -618,8 +723,12 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
                     plaudClient,
                     storage,
                     capState,
+                    seenRecordingIds,
                 );
 
+                pageNew += batchResult.newCount;
+                pageUpdated += batchResult.updatedCount;
+                pageCandidateCount += batchResult.importCandidates.length;
                 result.newRecordings += batchResult.newCount;
                 result.updatedRecordings += batchResult.updatedCount;
                 result.errors.push(...batchResult.errors);
@@ -637,15 +746,27 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
             } else if (plaudRecordings.length < SYNC_CONFIG.PAGE_SIZE) {
                 hasMore = false;
             } else if (
-                // Import can still need later pages after two no-change
-                // audio pages (#274).
-                !context.importPlaudContent &&
-                result.newRecordings === 0 &&
-                result.updatedRecordings === 0
+                pageNew === 0 &&
+                pageUpdated === 0 &&
+                pageCandidateCount === 0
             ) {
                 consecutiveEmptyPages++;
                 if (consecutiveEmptyPages >= 2) {
-                    hasMore = false;
+                    if (context.importPlaudContent) {
+                        if (
+                            !(await hasUnseenPlaudTranscriptGaps(
+                                userId,
+                                seenRecordingIds,
+                            ))
+                        ) {
+                            hasMore = false;
+                        }
+                    } else if (
+                        result.newRecordings === 0 &&
+                        result.updatedRecordings === 0
+                    ) {
+                        hasMore = false;
+                    }
                 }
             } else {
                 consecutiveEmptyPages = 0;
@@ -848,6 +969,19 @@ async function importPlaudContent(
     for (const candidate of candidates) {
         if (tokenDead) break;
         try {
+            const gaps = await loadPlaudContentGaps(
+                context.userId,
+                candidate.recordingId,
+                {
+                    isTrans: candidate.isTrans,
+                    isSummary: candidate.isSummary,
+                },
+            );
+            if (gaps.hasPlaudTranscript) {
+                transcriptImported.add(candidate.recordingId);
+            }
+            if (!gaps.needsTranscript && !gaps.needsSummary) continue;
+
             const detail = await plaudClient.getFileDetail(
                 candidate.plaudFileId,
             );
@@ -855,89 +989,51 @@ async function importPlaudContent(
 
             // --- Transcript (coexists with the user's own; gap-fill only) ---
             const transcriptLink = transcript?.data_link;
-            if (candidate.isTrans && isReady(transcript) && transcriptLink) {
-                const [existing] = await db
-                    .select({ id: transcriptions.id })
-                    .from(transcriptions)
-                    .where(
-                        and(
-                            eq(
-                                transcriptions.recordingId,
-                                candidate.recordingId,
-                            ),
-                            eq(transcriptions.userId, context.userId),
-                            eq(transcriptions.source, "plaud"),
-                        ),
-                    )
-                    .limit(1);
-
-                if (existing) {
-                    // Already imported on a prior sync. Treat as present so
-                    // 'plaud_only' still suppresses re-transcription.
-                    transcriptImported.add(candidate.recordingId);
-                } else {
-                    const parsed = parseTranscript(
-                        await plaudClient.fetchContentLink(transcriptLink),
-                    );
-                    if (parsed.text.trim()) {
-                        const { committed } = await upsertTranscription({
-                            userId: context.userId,
-                            recordingId: candidate.recordingId,
-                            text: parsed.text,
-                            detectedLanguage: parsed.language,
-                            source: "plaud",
-                            provider: "plaud",
-                            model: "plaud-native",
-                        });
-                        if (committed) {
-                            transcriptImported.add(candidate.recordingId);
-                            await emitEvent(
-                                "transcription.completed",
-                                context.userId,
-                                candidate.recordingId,
-                            );
-                        }
+            if (gaps.needsTranscript && isReady(transcript) && transcriptLink) {
+                const parsed = parseTranscript(
+                    await plaudClient.fetchContentLink(transcriptLink),
+                );
+                if (parsed.text.trim()) {
+                    const { committed } = await upsertTranscription({
+                        userId: context.userId,
+                        recordingId: candidate.recordingId,
+                        text: parsed.text,
+                        detectedLanguage: parsed.language,
+                        source: "plaud",
+                        provider: "plaud",
+                        model: "plaud-native",
+                    });
+                    if (committed) {
+                        transcriptImported.add(candidate.recordingId);
+                        await emitEvent(
+                            "transcription.completed",
+                            context.userId,
+                            candidate.recordingId,
+                        );
                     }
                 }
             }
 
             // --- Summary (single per recording; gap-fill only) ---
             const summaryLink = summary?.data_link;
-            if (candidate.isSummary && isReady(summary) && summaryLink) {
-                const [existing] = await db
-                    .select({ id: aiEnhancements.id })
-                    .from(aiEnhancements)
-                    .where(
-                        and(
-                            eq(
-                                aiEnhancements.recordingId,
-                                candidate.recordingId,
-                            ),
-                            eq(aiEnhancements.userId, context.userId),
-                        ),
-                    )
-                    .limit(1);
-
-                if (!existing) {
-                    // Prefer the inline copy (no S3 round-trip, no presign
-                    // expiry, #203); fall back to the presigned link.
-                    const inline = findInlineContent(detail, summary?.data_id);
-                    const parsed = parseSummary(
-                        inline ??
-                            (await plaudClient.fetchContentLink(summaryLink)),
-                    );
-                    if (parsed.summary.trim()) {
-                        await upsertEnhancement({
-                            userId: context.userId,
-                            recordingId: candidate.recordingId,
-                            summary: parsed.summary,
-                            keyPoints: parsed.keyPoints,
-                            actionItems: parsed.actionItems,
-                            source: "plaud",
-                            provider: "plaud",
-                            model: "plaud-native",
-                        });
-                    }
+            if (gaps.needsSummary && isReady(summary) && summaryLink) {
+                // Prefer the inline copy (no S3 round-trip, no presign
+                // expiry, #203); fall back to the presigned link.
+                const inline = findInlineContent(detail, summary?.data_id);
+                const parsed = parseSummary(
+                    inline ?? (await plaudClient.fetchContentLink(summaryLink)),
+                );
+                if (parsed.summary.trim()) {
+                    await upsertEnhancement({
+                        userId: context.userId,
+                        recordingId: candidate.recordingId,
+                        summary: parsed.summary,
+                        keyPoints: parsed.keyPoints,
+                        actionItems: parsed.actionItems,
+                        source: "plaud",
+                        provider: "plaud",
+                        model: "plaud-native",
+                    });
                 }
             }
         } catch (error) {

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, ne, notInArray } from "drizzle-orm";
+import { and, eq, isNull, ne, notInArray, or } from "drizzle-orm";
 import { db } from "@/db";
 import {
     aiEnhancements,
@@ -229,14 +229,14 @@ async function loadPlaudContentGaps(
     return { needsTranscript, needsSummary, hasPlaudTranscript };
 }
 
-async function hasUnseenPlaudTranscriptGaps(
+async function hasUnseenPlaudContentGaps(
     userId: string,
     seenRecordingIds: Set<string>,
 ): Promise<boolean> {
     const conditions = [
         eq(recordings.userId, userId),
         isNull(recordings.deletedAt),
-        isNull(transcriptions.id),
+        or(isNull(transcriptions.id), isNull(aiEnhancements.id)),
     ];
     if (seenRecordingIds.size > 0) {
         conditions.push(notInArray(recordings.id, [...seenRecordingIds]));
@@ -251,6 +251,13 @@ async function hasUnseenPlaudTranscriptGaps(
                 eq(transcriptions.recordingId, recordings.id),
                 eq(transcriptions.userId, userId),
                 eq(transcriptions.source, "plaud"),
+            ),
+        )
+        .leftJoin(
+            aiEnhancements,
+            and(
+                eq(aiEnhancements.recordingId, recordings.id),
+                eq(aiEnhancements.userId, userId),
             ),
         )
         .where(and(...conditions))
@@ -754,7 +761,7 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
                 if (consecutiveEmptyPages >= 2) {
                     if (context.importPlaudContent) {
                         if (
-                            !(await hasUnseenPlaudTranscriptGaps(
+                            !(await hasUnseenPlaudContentGaps(
                                 userId,
                                 seenRecordingIds,
                             ))

--- a/src/lib/sync/sync-recordings.ts
+++ b/src/lib/sync/sync-recordings.ts
@@ -226,6 +226,19 @@ async function processRecording(
             existingRecording &&
             existingRecording.plaudVersion === versionKey
         ) {
+            // Audio is current, but Plaud may have finished a transcript or
+            // summary without bumping version_ms. Keep those rows eligible
+            // for content backfill (#274). Tombstones stay skipped.
+            if (context.importPlaudContent && !existingRecording.deletedAt) {
+                return {
+                    status: "skipped",
+                    recordingId: existingRecording.id,
+                    importCandidate: buildImportCandidate(
+                        existingRecording.id,
+                        plaudRecording,
+                    ),
+                };
+            }
             return { status: "skipped" };
         }
 
@@ -626,6 +639,12 @@ async function runSyncRecordingsForUser(userId: string): Promise<SyncResult> {
             } else if (plaudRecordings.length < SYNC_CONFIG.PAGE_SIZE) {
                 hasMore = false;
             } else if (
+                // Two no-change pages imply older audio is unchanged
+                // (list is edit_time desc). That must not apply while
+                // import is on: Plaud can attach transcript/summary to
+                // older files without a version bump, and those sit
+                // past the first two pages (#274).
+                !context.importPlaudContent &&
                 result.newRecordings === 0 &&
                 result.updatedRecordings === 0
             ) {
@@ -834,14 +853,10 @@ async function importPlaudContent(
     for (const candidate of candidates) {
         if (tokenDead) break;
         try {
-            const detail = await plaudClient.getFileDetail(
-                candidate.plaudFileId,
-            );
-            const { transcript, summary } = selectContentItems(detail);
-
-            // --- Transcript (coexists with the user's own; gap-fill only) ---
-            const transcriptLink = transcript?.data_link;
-            if (candidate.isTrans && isReady(transcript) && transcriptLink) {
+            // Gap-fill checks first so a version-unchanged backfill walk
+            // (#274) does not call getFileDetail for rows already imported.
+            let needsTranscript = false;
+            if (candidate.isTrans) {
                 const [existing] = await db
                     .select({ id: transcriptions.id })
                     .from(transcriptions)
@@ -862,34 +877,12 @@ async function importPlaudContent(
                     // 'plaud_only' still suppresses re-transcription.
                     transcriptImported.add(candidate.recordingId);
                 } else {
-                    const parsed = parseTranscript(
-                        await plaudClient.fetchContentLink(transcriptLink),
-                    );
-                    if (parsed.text.trim()) {
-                        const { committed } = await upsertTranscription({
-                            userId: context.userId,
-                            recordingId: candidate.recordingId,
-                            text: parsed.text,
-                            detectedLanguage: parsed.language,
-                            source: "plaud",
-                            provider: "plaud",
-                            model: "plaud-native",
-                        });
-                        if (committed) {
-                            transcriptImported.add(candidate.recordingId);
-                            await emitEvent(
-                                "transcription.completed",
-                                context.userId,
-                                candidate.recordingId,
-                            );
-                        }
-                    }
+                    needsTranscript = true;
                 }
             }
 
-            // --- Summary (single per recording; gap-fill only) ---
-            const summaryLink = summary?.data_link;
-            if (candidate.isSummary && isReady(summary) && summaryLink) {
+            let needsSummary = false;
+            if (candidate.isSummary) {
                 const [existing] = await db
                     .select({ id: aiEnhancements.id })
                     .from(aiEnhancements)
@@ -903,27 +896,63 @@ async function importPlaudContent(
                         ),
                     )
                     .limit(1);
+                if (!existing) needsSummary = true;
+            }
 
-                if (!existing) {
-                    // Prefer the inline copy (no S3 round-trip, no presign
-                    // expiry, #203); fall back to the presigned link.
-                    const inline = findInlineContent(detail, summary?.data_id);
-                    const parsed = parseSummary(
-                        inline ??
-                            (await plaudClient.fetchContentLink(summaryLink)),
-                    );
-                    if (parsed.summary.trim()) {
-                        await upsertEnhancement({
-                            userId: context.userId,
-                            recordingId: candidate.recordingId,
-                            summary: parsed.summary,
-                            keyPoints: parsed.keyPoints,
-                            actionItems: parsed.actionItems,
-                            source: "plaud",
-                            provider: "plaud",
-                            model: "plaud-native",
-                        });
+            if (!needsTranscript && !needsSummary) continue;
+
+            const detail = await plaudClient.getFileDetail(
+                candidate.plaudFileId,
+            );
+            const { transcript, summary } = selectContentItems(detail);
+
+            // --- Transcript (coexists with the user's own; gap-fill only) ---
+            const transcriptLink = transcript?.data_link;
+            if (needsTranscript && isReady(transcript) && transcriptLink) {
+                const parsed = parseTranscript(
+                    await plaudClient.fetchContentLink(transcriptLink),
+                );
+                if (parsed.text.trim()) {
+                    const { committed } = await upsertTranscription({
+                        userId: context.userId,
+                        recordingId: candidate.recordingId,
+                        text: parsed.text,
+                        detectedLanguage: parsed.language,
+                        source: "plaud",
+                        provider: "plaud",
+                        model: "plaud-native",
+                    });
+                    if (committed) {
+                        transcriptImported.add(candidate.recordingId);
+                        await emitEvent(
+                            "transcription.completed",
+                            context.userId,
+                            candidate.recordingId,
+                        );
                     }
+                }
+            }
+
+            // --- Summary (single per recording; gap-fill only) ---
+            const summaryLink = summary?.data_link;
+            if (needsSummary && isReady(summary) && summaryLink) {
+                // Prefer the inline copy (no S3 round-trip, no presign
+                // expiry, #203); fall back to the presigned link.
+                const inline = findInlineContent(detail, summary?.data_id);
+                const parsed = parseSummary(
+                    inline ?? (await plaudClient.fetchContentLink(summaryLink)),
+                );
+                if (parsed.summary.trim()) {
+                    await upsertEnhancement({
+                        userId: context.userId,
+                        recordingId: candidate.recordingId,
+                        summary: parsed.summary,
+                        keyPoints: parsed.keyPoints,
+                        actionItems: parsed.actionItems,
+                        source: "plaud",
+                        provider: "plaud",
+                        model: "plaud-native",
+                    });
                 }
             }
         } catch (error) {

--- a/src/tests/regressions/274-pagination-content-backfill.test.ts
+++ b/src/tests/regressions/274-pagination-content-backfill.test.ts
@@ -65,7 +65,10 @@ import {
 import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { resetAutoTranscribeStateForTests } from "@/lib/sync/auto-transcribe-state";
 import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
-import { upsertTranscription } from "@/lib/transcription/persist";
+import {
+    upsertEnhancement,
+    upsertTranscription,
+} from "@/lib/transcription/persist";
 
 const USER_ID = "user-274";
 const PAGE_SIZE = 50;
@@ -74,6 +77,7 @@ type Fixture = {
     rec: ReturnType<typeof plaudRecording>;
     deletedAt?: Date | null;
     hasPlaudTranscript?: boolean;
+    hasSummary?: boolean;
 };
 
 function plaudRecording(
@@ -101,12 +105,18 @@ function plaudRecording(
 
 function fixture(
     index: number,
-    opts: { deletedAt?: Date | null; hasPlaudTranscript?: boolean } = {},
+    opts: {
+        deletedAt?: Date | null;
+        hasPlaudTranscript?: boolean;
+        hasSummary?: boolean;
+        is_summary?: boolean;
+    } = {},
 ): Fixture {
     return {
-        rec: plaudRecording(index),
+        rec: plaudRecording(index, { is_summary: opts.is_summary }),
         deletedAt: opts.deletedAt,
         hasPlaudTranscript: opts.hasPlaudTranscript,
+        hasSummary: opts.hasSummary,
     };
 }
 
@@ -125,19 +135,38 @@ function findLocalId(clause: unknown): string | undefined {
     return undefined;
 }
 
-function readyDetail(fileId: string) {
+function readyDetail(fileId: string, opts: { summary?: boolean } = {}) {
+    const content_list = [
+        {
+            data_id: `source_transaction:${fileId}`,
+            data_type: "transaction",
+            task_status: 1,
+            data_link: `https://s3.example/${fileId}.json`,
+        },
+    ];
+    const pre_download_content_list: {
+        data_id: string;
+        data_content: string;
+    }[] = [];
+    if (opts.summary) {
+        const dataId = `auto_sum:${fileId}`;
+        content_list.push({
+            data_id: dataId,
+            data_type: "auto_sum_note",
+            task_status: 1,
+            data_link: `https://s3.example/${fileId}-sum.json`,
+        });
+        pre_download_content_list.push({
+            data_id: dataId,
+            data_content: JSON.stringify({ summary: "imported summary" }),
+        });
+    }
     return {
         status: 0,
         data: {
             file_id: fileId,
-            content_list: [
-                {
-                    data_id: `source_transaction:${fileId}`,
-                    data_type: "transaction",
-                    task_status: 1,
-                    data_link: `https://s3.example/${fileId}.json`,
-                },
-            ],
+            content_list,
+            pre_download_content_list,
         },
     };
 }
@@ -190,7 +219,11 @@ function mockSelects(opts: {
                     if (joined) {
                         const unseen = opts.fixtures
                             .slice(recordingLookup)
-                            .find((f) => !f.deletedAt && !f.hasPlaudTranscript);
+                            .find(
+                                (f) =>
+                                    !f.deletedAt &&
+                                    (!f.hasPlaudTranscript || !f.hasSummary),
+                            );
                         return Promise.resolve(
                             unseen ? [{ id: `local-${unseen.rec.id}` }] : [],
                         );
@@ -215,6 +248,11 @@ function mockSelects(opts: {
                     return Promise.resolve([]);
                 }
                 if (table === aiEnhancements) {
+                    const localId = findLocalId(whereClause);
+                    const f = localId ? byLocalId.get(localId) : undefined;
+                    if (f?.hasSummary) {
+                        return Promise.resolve([{ id: `sum-${f.rec.id}` }]);
+                    }
                     return Promise.resolve([]);
                 }
                 return Promise.resolve([]);
@@ -346,13 +384,17 @@ describe("Issue #274 — pagination content backfill", () => {
     });
 
     it("stops after two empty pages when every seen row is already imported", async () => {
+        const imported = {
+            hasPlaudTranscript: true,
+            hasSummary: true,
+        };
         const page1 = Array.from({ length: PAGE_SIZE }, (_, i) =>
-            fixture(i, { hasPlaudTranscript: true }),
+            fixture(i, imported),
         );
         const page2 = Array.from({ length: PAGE_SIZE }, (_, i) =>
-            fixture(PAGE_SIZE + i, { hasPlaudTranscript: true }),
+            fixture(PAGE_SIZE + i, imported),
         );
-        const older = fixture(PAGE_SIZE * 2, { hasPlaudTranscript: true });
+        const older = fixture(PAGE_SIZE * 2, imported);
         const { getRecordings, getFileDetail } = mockPlaudPages([
             page1.map((f) => f.rec),
             page2.map((f) => f.rec),
@@ -407,6 +449,58 @@ describe("Issue #274 — pagination content backfill", () => {
         expect(upsertTranscription).toHaveBeenCalledWith(
             expect.objectContaining({
                 recordingId: `local-${older.rec.id}`,
+            }),
+        );
+    });
+
+    it("keeps paging when an older row has a Plaud transcript but still needs its summary", async () => {
+        const imported = {
+            hasPlaudTranscript: true,
+            hasSummary: true,
+        };
+        const page1 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+            fixture(i, imported),
+        );
+        const page2 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+            fixture(PAGE_SIZE + i, imported),
+        );
+        const older = fixture(PAGE_SIZE * 2, {
+            hasPlaudTranscript: true,
+            is_summary: true,
+        });
+        const { getRecordings, getFileDetail } = mockPlaudPages(
+            [page1.map((f) => f.rec), page2.map((f) => f.rec), [older.rec]],
+            {
+                getFileDetail: vi.fn(async (fileId: string) =>
+                    readyDetail(fileId, { summary: true }),
+                ),
+            },
+        );
+        mockSelects({
+            importPlaudContent: true,
+            fixtures: [...page1, ...page2, older],
+        });
+
+        await syncRecordingsForUser(USER_ID);
+
+        expect(getRecordings).toHaveBeenCalledWith(
+            PAGE_SIZE * 2,
+            PAGE_SIZE,
+            0,
+            "edit_time",
+            true,
+        );
+        expect(getFileDetail.mock.calls.map((c) => c[0])).toEqual([
+            older.rec.id,
+        ]);
+        expect(upsertTranscription).not.toHaveBeenCalled();
+        expect(upsertEnhancement).toHaveBeenCalledTimes(1);
+        expect(upsertEnhancement).toHaveBeenCalledWith(
+            expect.objectContaining({
+                userId: USER_ID,
+                recordingId: `local-${older.rec.id}`,
+                source: "plaud",
+                summary: "imported summary",
             }),
         );
     });

--- a/src/tests/regressions/274-pagination-content-backfill.test.ts
+++ b/src/tests/regressions/274-pagination-content-backfill.test.ts
@@ -54,7 +54,14 @@ vi.mock("@/lib/webhooks/emit", () => ({
 }));
 
 import { db } from "@/db";
-import { plaudConnections, recordings, userSettings, users } from "@/db/schema";
+import {
+    aiEnhancements,
+    plaudConnections,
+    recordings,
+    transcriptions,
+    userSettings,
+    users,
+} from "@/db/schema";
 import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { resetAutoTranscribeStateForTests } from "@/lib/sync/auto-transcribe-state";
 import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
@@ -62,6 +69,12 @@ import { upsertTranscription } from "@/lib/transcription/persist";
 
 const USER_ID = "user-274";
 const PAGE_SIZE = 50;
+
+type Fixture = {
+    rec: ReturnType<typeof plaudRecording>;
+    deletedAt?: Date | null;
+    hasPlaudTranscript?: boolean;
+};
 
 function plaudRecording(
     index: number,
@@ -86,10 +99,30 @@ function plaudRecording(
     };
 }
 
-function pageOf(startIndex: number, count: number) {
-    return Array.from({ length: count }, (_, i) =>
-        plaudRecording(startIndex + i),
-    );
+function fixture(
+    index: number,
+    opts: { deletedAt?: Date | null; hasPlaudTranscript?: boolean } = {},
+): Fixture {
+    return {
+        rec: plaudRecording(index),
+        deletedAt: opts.deletedAt,
+        hasPlaudTranscript: opts.hasPlaudTranscript,
+    };
+}
+
+function findLocalId(clause: unknown): string | undefined {
+    const seen = new Set<unknown>();
+    const stack: unknown[] = [clause];
+    while (stack.length > 0) {
+        const cur = stack.pop();
+        if (cur == null || seen.has(cur)) continue;
+        if (typeof cur === "string" && cur.startsWith("local-")) return cur;
+        if (typeof cur !== "object") continue;
+        seen.add(cur);
+        if (Array.isArray(cur)) stack.push(...cur);
+        else stack.push(...Object.values(cur as Record<string, unknown>));
+    }
+    return undefined;
 }
 
 function readyDetail(fileId: string) {
@@ -111,50 +144,110 @@ function readyDetail(fileId: string) {
 
 function mockSelects(opts: {
     importPlaudContent: boolean;
-    recordingsInOrder: ReturnType<typeof plaudRecording>[];
+    fixtures: Fixture[];
 }) {
+    const byLocalId = new Map(
+        opts.fixtures.map((f) => [`local-${f.rec.id}`, f]),
+    );
     let recordingLookup = 0;
 
-    (db.select as Mock).mockImplementation(() => ({
-        from: (table: unknown) => {
-            const resolve = (rows: unknown[]) => ({
-                where: () => ({
-                    limit: () => Promise.resolve(rows),
-                }),
-            });
+    (db.select as Mock).mockImplementation(() => {
+        let table: unknown;
+        let joined = false;
+        let whereClause: unknown;
+        const chain = {
+            from: (next: unknown) => {
+                table = next;
+                return chain;
+            },
+            leftJoin: () => {
+                joined = true;
+                return chain;
+            },
+            where: (clause?: unknown) => {
+                whereClause = clause;
+                return chain;
+            },
+            limit: () => {
+                if (table === plaudConnections) {
+                    return Promise.resolve([
+                        {
+                            id: "conn-1",
+                            userId: USER_ID,
+                            bearerToken: "encrypted-token",
+                        },
+                    ]);
+                }
+                if (table === userSettings) {
+                    return Promise.resolve([
+                        { importPlaudContent: opts.importPlaudContent },
+                    ]);
+                }
+                if (table === users) {
+                    return Promise.resolve([{ email: "test@example.com" }]);
+                }
+                if (table === recordings) {
+                    if (joined) {
+                        const unseen = opts.fixtures
+                            .slice(recordingLookup)
+                            .find((f) => !f.deletedAt && !f.hasPlaudTranscript);
+                        return Promise.resolve(
+                            unseen ? [{ id: `local-${unseen.rec.id}` }] : [],
+                        );
+                    }
+                    const f = opts.fixtures[recordingLookup++];
+                    if (!f) return Promise.resolve([]);
+                    return Promise.resolve([
+                        {
+                            id: `local-${f.rec.id}`,
+                            plaudFileId: f.rec.id,
+                            plaudVersion: "1000",
+                            deletedAt: f.deletedAt ?? null,
+                        },
+                    ]);
+                }
+                if (table === transcriptions) {
+                    const localId = findLocalId(whereClause);
+                    const f = localId ? byLocalId.get(localId) : undefined;
+                    if (f?.hasPlaudTranscript) {
+                        return Promise.resolve([{ id: `tr-${f.rec.id}` }]);
+                    }
+                    return Promise.resolve([]);
+                }
+                if (table === aiEnhancements) {
+                    return Promise.resolve([]);
+                }
+                return Promise.resolve([]);
+            },
+        };
+        return chain;
+    });
+}
 
-            if (table === plaudConnections) {
-                return resolve([
-                    {
-                        id: "conn-1",
-                        userId: USER_ID,
-                        bearerToken: "encrypted-token",
-                    },
-                ]);
-            }
-            if (table === userSettings) {
-                return resolve([
-                    { importPlaudContent: opts.importPlaudContent },
-                ]);
-            }
-            if (table === users) {
-                return resolve([{ email: "test@example.com" }]);
-            }
-            if (table === recordings) {
-                const rec = opts.recordingsInOrder[recordingLookup++];
-                if (!rec) return resolve([]);
-                return resolve([
-                    {
-                        id: `local-${rec.id}`,
-                        plaudFileId: rec.id,
-                        plaudVersion: "1000",
-                        deletedAt: null,
-                    },
-                ]);
-            }
-            return resolve([]);
-        },
-    }));
+function mockPlaudPages(
+    pages: ReturnType<typeof plaudRecording>[][],
+    extras: {
+        getFileDetail?: Mock;
+        fetchContentLink?: Mock;
+    } = {},
+) {
+    const getRecordings = vi.fn(async (skip: number) => {
+        const pageIndex = skip / PAGE_SIZE;
+        return { data_file_list: pages[pageIndex] ?? [] };
+    });
+    const getFileDetail =
+        extras.getFileDetail ??
+        vi.fn(async (fileId: string) => readyDetail(fileId));
+    const fetchContentLink =
+        extras.fetchContentLink ??
+        vi.fn(async () => [{ speaker: 1, content: "hello from plaud" }]);
+    (createPlaudClient as Mock).mockResolvedValue({
+        getRecordings,
+        getFileDetail,
+        fetchContentLink,
+        downloadRecording: vi.fn(),
+    });
+    return { getRecordings, getFileDetail };
 }
 
 describe("Issue #274 — pagination content backfill", () => {
@@ -169,33 +262,24 @@ describe("Issue #274 — pagination content backfill", () => {
     });
 
     it("pages past two unchanged versions and imports a distinct older recording", async () => {
-        const page1 = pageOf(0, PAGE_SIZE);
-        const page2 = pageOf(PAGE_SIZE, PAGE_SIZE);
-        const older = plaudRecording(PAGE_SIZE * 2);
-        const page3 = [older];
-        const all = [...page1, ...page2, ...page3];
-
-        const getRecordings = vi.fn(async (skip: number) => {
-            if (skip === 0) return { data_file_list: page1 };
-            if (skip === PAGE_SIZE) return { data_file_list: page2 };
-            if (skip === PAGE_SIZE * 2) return { data_file_list: page3 };
-            return { data_file_list: [] };
-        });
-        const getFileDetail = vi.fn(async (fileId: string) =>
-            readyDetail(fileId),
+        const tombstone = fixture(0, { deletedAt: new Date("2024-02-01") });
+        const alreadyImported = fixture(1, { hasPlaudTranscript: true });
+        const page1Rest = Array.from({ length: PAGE_SIZE - 2 }, (_, i) =>
+            fixture(i + 2),
         );
-        const fetchContentLink = vi.fn(async () => [
-            { speaker: 1, content: "hello from plaud" },
+        const page1 = [tombstone, alreadyImported, ...page1Rest];
+        const page2 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+            fixture(PAGE_SIZE + i),
+        );
+        const older = fixture(PAGE_SIZE * 2);
+        const fixtures = [...page1, ...page2, older];
+
+        const { getRecordings, getFileDetail } = mockPlaudPages([
+            page1.map((f) => f.rec),
+            page2.map((f) => f.rec),
+            [older.rec],
         ]);
-
-        (createPlaudClient as Mock).mockResolvedValue({
-            getRecordings,
-            getFileDetail,
-            fetchContentLink,
-            downloadRecording: vi.fn(),
-        });
-
-        mockSelects({ importPlaudContent: true, recordingsInOrder: all });
+        mockSelects({ importPlaudContent: true, fixtures });
 
         const result = await syncRecordingsForUser(USER_ID);
 
@@ -208,42 +292,46 @@ describe("Issue #274 — pagination content backfill", () => {
             "edit_time",
             true,
         );
-        expect(getFileDetail).toHaveBeenCalledWith(older.id);
-        expect(getFileDetail.mock.calls.map((c) => c[0])).toEqual(
-            all.map((r) => r.id),
-        );
+
+        const fetched = getFileDetail.mock.calls.map((c) => c[0] as string);
+        expect(fetched).not.toContain(tombstone.rec.id);
+        expect(fetched).not.toContain(alreadyImported.rec.id);
+        expect(fetched).toContain(older.rec.id);
         expect(upsertTranscription).toHaveBeenCalledWith(
             expect.objectContaining({
                 userId: USER_ID,
-                recordingId: `local-${older.id}`,
+                recordingId: `local-${older.rec.id}`,
                 source: "plaud",
                 text: "Speaker 1: hello from plaud",
             }),
         );
-        expect(upsertTranscription).toHaveBeenCalledTimes(all.length);
+        expect(upsertTranscription).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                recordingId: `local-${tombstone.rec.id}`,
+            }),
+        );
+        expect(upsertTranscription).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                recordingId: `local-${alreadyImported.rec.id}`,
+            }),
+        );
     });
 
     it("still stops after two no-change pages when Plaud import is off", async () => {
-        const page1 = pageOf(0, PAGE_SIZE);
-        const page2 = pageOf(PAGE_SIZE, PAGE_SIZE);
-        const older = plaudRecording(PAGE_SIZE * 2);
-        const all = [...page1, ...page2, older];
-
-        const getRecordings = vi.fn(async (skip: number) => {
-            if (skip === 0) return { data_file_list: page1 };
-            if (skip === PAGE_SIZE) return { data_file_list: page2 };
-            if (skip === PAGE_SIZE * 2) return { data_file_list: [older] };
-            return { data_file_list: [] };
+        const page1 = Array.from({ length: PAGE_SIZE }, (_, i) => fixture(i));
+        const page2 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+            fixture(PAGE_SIZE + i),
+        );
+        const older = fixture(PAGE_SIZE * 2);
+        const { getRecordings, getFileDetail } = mockPlaudPages([
+            page1.map((f) => f.rec),
+            page2.map((f) => f.rec),
+            [older.rec],
+        ]);
+        mockSelects({
+            importPlaudContent: false,
+            fixtures: [...page1, ...page2, older],
         });
-        const getFileDetail = vi.fn();
-
-        (createPlaudClient as Mock).mockResolvedValue({
-            getRecordings,
-            getFileDetail,
-            downloadRecording: vi.fn(),
-        });
-
-        mockSelects({ importPlaudContent: false, recordingsInOrder: all });
 
         const result = await syncRecordingsForUser(USER_ID);
 
@@ -255,5 +343,71 @@ describe("Issue #274 — pagination content backfill", () => {
         ]);
         expect(getFileDetail).not.toHaveBeenCalled();
         expect(upsertTranscription).not.toHaveBeenCalled();
+    });
+
+    it("stops after two empty pages when every seen row is already imported", async () => {
+        const page1 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+            fixture(i, { hasPlaudTranscript: true }),
+        );
+        const page2 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+            fixture(PAGE_SIZE + i, { hasPlaudTranscript: true }),
+        );
+        const older = fixture(PAGE_SIZE * 2, { hasPlaudTranscript: true });
+        const { getRecordings, getFileDetail } = mockPlaudPages([
+            page1.map((f) => f.rec),
+            page2.map((f) => f.rec),
+            [older.rec],
+        ]);
+        mockSelects({
+            importPlaudContent: true,
+            fixtures: [...page1, ...page2, older],
+        });
+
+        await syncRecordingsForUser(USER_ID);
+
+        expect(getRecordings.mock.calls.map((c) => c[0])).toEqual([
+            0,
+            PAGE_SIZE,
+        ]);
+        expect(getFileDetail).not.toHaveBeenCalled();
+        expect(upsertTranscription).not.toHaveBeenCalled();
+    });
+
+    it("keeps paging when recent pages are imported and an older row still needs content", async () => {
+        const page1 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+            fixture(i, { hasPlaudTranscript: true }),
+        );
+        const page2 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+            fixture(PAGE_SIZE + i, { hasPlaudTranscript: true }),
+        );
+        const older = fixture(PAGE_SIZE * 2);
+        const { getRecordings, getFileDetail } = mockPlaudPages([
+            page1.map((f) => f.rec),
+            page2.map((f) => f.rec),
+            [older.rec],
+        ]);
+        mockSelects({
+            importPlaudContent: true,
+            fixtures: [...page1, ...page2, older],
+        });
+
+        await syncRecordingsForUser(USER_ID);
+
+        expect(getRecordings).toHaveBeenCalledWith(
+            PAGE_SIZE * 2,
+            PAGE_SIZE,
+            0,
+            "edit_time",
+            true,
+        );
+        expect(getFileDetail.mock.calls.map((c) => c[0])).toEqual([
+            older.rec.id,
+        ]);
+        expect(upsertTranscription).toHaveBeenCalledTimes(1);
+        expect(upsertTranscription).toHaveBeenCalledWith(
+            expect.objectContaining({
+                recordingId: `local-${older.rec.id}`,
+            }),
+        );
     });
 });

--- a/src/tests/regressions/274-pagination-content-backfill.test.ts
+++ b/src/tests/regressions/274-pagination-content-backfill.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Regression for #274: Plaud list pagination stopped after two pages
+ * with no new/updated audio, and a version-match skip never built an
+ * import candidate. Older recordings therefore never received Plaud
+ * transcript/summary backfill. #282's auto-transcribe retry does not
+ * cover this path.
+ */
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+vi.mock("@/lib/env", () => ({
+    env: {
+        DEFAULT_STORAGE_TYPE: "local",
+        ENCRYPTION_KEY:
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    },
+}));
+
+vi.mock("@/db", () => ({
+    db: {
+        select: vi.fn(),
+        insert: vi.fn(),
+        update: vi.fn(),
+        transaction: vi.fn(),
+    },
+}));
+
+vi.mock("@/lib/plaud/client-factory", () => ({
+    createPlaudClient: vi.fn(),
+}));
+
+vi.mock("@/lib/storage/factory", () => ({
+    createUserStorageProvider: vi.fn().mockResolvedValue({
+        uploadFile: vi.fn().mockResolvedValue(undefined),
+        downloadFile: vi.fn().mockResolvedValue(Buffer.from("audio-data")),
+    }),
+}));
+
+vi.mock("@/lib/notifications/bark", () => ({
+    sendNewRecordingBarkNotification: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("@/lib/notifications/email", () => ({
+    sendNewRecordingEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/transcription/transcribe-recording", () => ({
+    transcribeRecording: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock("@/lib/transcription/persist", () => ({
+    upsertTranscription: vi.fn().mockResolvedValue({ committed: true }),
+    upsertEnhancement: vi.fn().mockResolvedValue({ committed: true }),
+}));
+
+vi.mock("@/lib/webhooks/emit", () => ({
+    emitEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { db } from "@/db";
+import {
+    aiEnhancements,
+    plaudConnections,
+    recordings,
+    transcriptions,
+    userSettings,
+    users,
+} from "@/db/schema";
+import { createPlaudClient } from "@/lib/plaud/client-factory";
+import { resetAutoTranscribeStateForTests } from "@/lib/sync/auto-transcribe-state";
+import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
+import { upsertTranscription } from "@/lib/transcription/persist";
+
+const USER_ID = "user-274";
+const PAGE_SIZE = 50;
+
+function plaudRecording(
+    index: number,
+    overrides: { is_trans?: boolean; is_summary?: boolean } = {},
+) {
+    return {
+        id: `plaud-${index}`,
+        filename: `Recording ${index}.mp3`,
+        duration: 60000,
+        start_time: "2024-01-01T10:00:00Z",
+        end_time: "2024-01-01T10:01:00Z",
+        filesize: 1024000,
+        file_md5: `md5-${index}`,
+        serial_number: "SN123",
+        version_ms: 1000,
+        timezone: 0,
+        zonemins: 0,
+        scene: 0,
+        is_trash: false,
+        is_trans: overrides.is_trans ?? true,
+        is_summary: overrides.is_summary ?? false,
+    };
+}
+
+function pageOf(startIndex: number, count: number) {
+    return Array.from({ length: count }, (_, i) =>
+        plaudRecording(startIndex + i),
+    );
+}
+
+function readyDetail(fileId: string) {
+    return {
+        status: 0,
+        data: {
+            file_id: fileId,
+            content_list: [
+                {
+                    data_id: `source_transaction:${fileId}`,
+                    data_type: "transaction",
+                    task_status: 1,
+                    data_link: `https://s3.example/${fileId}.json`,
+                },
+            ],
+        },
+    };
+}
+
+function mockSelects(opts: {
+    importPlaudContent: boolean;
+    recordingsInOrder: ReturnType<typeof plaudRecording>[];
+}) {
+    let recordingLookup = 0;
+
+    (db.select as Mock).mockImplementation(() => ({
+        from: (table: unknown) => {
+            const resolve = (rows: unknown[]) => ({
+                where: () => ({
+                    limit: () => Promise.resolve(rows),
+                }),
+            });
+
+            if (table === plaudConnections) {
+                return resolve([
+                    {
+                        id: "conn-1",
+                        userId: USER_ID,
+                        bearerToken: "encrypted-token",
+                    },
+                ]);
+            }
+            if (table === userSettings) {
+                return resolve([
+                    { importPlaudContent: opts.importPlaudContent },
+                ]);
+            }
+            if (table === users) {
+                return resolve([{ email: "test@example.com" }]);
+            }
+            if (table === recordings) {
+                const rec = opts.recordingsInOrder[recordingLookup++];
+                if (!rec) return resolve([]);
+                return resolve([
+                    {
+                        id: `local-${rec.id}`,
+                        plaudFileId: rec.id,
+                        plaudVersion: "1000",
+                        deletedAt: null,
+                    },
+                ]);
+            }
+            return resolve([]);
+        },
+    }));
+}
+
+describe("Issue #274 — pagination content backfill", () => {
+    beforeEach(() => {
+        resetAutoTranscribeStateForTests();
+        vi.clearAllMocks();
+        (db.update as Mock).mockReturnValue({
+            set: vi.fn().mockReturnValue({
+                where: vi.fn().mockResolvedValue(undefined),
+            }),
+        });
+    });
+
+    it("pages past two unchanged versions and imports a distinct older recording", async () => {
+        const page1 = pageOf(0, PAGE_SIZE);
+        const page2 = pageOf(PAGE_SIZE, PAGE_SIZE);
+        const older = plaudRecording(PAGE_SIZE * 2);
+        const page3 = [older];
+        const all = [...page1, ...page2, ...page3];
+
+        const getRecordings = vi.fn(async (skip: number) => {
+            if (skip === 0) return { data_file_list: page1 };
+            if (skip === PAGE_SIZE) return { data_file_list: page2 };
+            if (skip === PAGE_SIZE * 2) return { data_file_list: page3 };
+            return { data_file_list: [] };
+        });
+        const getFileDetail = vi.fn(async (fileId: string) =>
+            readyDetail(fileId),
+        );
+        const fetchContentLink = vi.fn(async () => [
+            { speaker: 1, content: "hello from plaud" },
+        ]);
+
+        (createPlaudClient as Mock).mockResolvedValue({
+            getRecordings,
+            getFileDetail,
+            fetchContentLink,
+            downloadRecording: vi.fn(),
+        });
+
+        mockSelects({ importPlaudContent: true, recordingsInOrder: all });
+
+        const result = await syncRecordingsForUser(USER_ID);
+
+        expect(result.newRecordings).toBe(0);
+        expect(result.updatedRecordings).toBe(0);
+        expect(getRecordings).toHaveBeenCalledWith(
+            PAGE_SIZE * 2,
+            PAGE_SIZE,
+            0,
+            "edit_time",
+            true,
+        );
+        expect(getFileDetail).toHaveBeenCalledWith(older.id);
+        expect(getFileDetail.mock.calls.map((c) => c[0])).toEqual(
+            all.map((r) => r.id),
+        );
+        expect(upsertTranscription).toHaveBeenCalledWith(
+            expect.objectContaining({
+                userId: USER_ID,
+                recordingId: `local-${older.id}`,
+                source: "plaud",
+                text: "Speaker 1: hello from plaud",
+            }),
+        );
+        expect(upsertTranscription).toHaveBeenCalledTimes(all.length);
+    });
+
+    it("still stops after two no-change pages when Plaud import is off", async () => {
+        const page1 = pageOf(0, PAGE_SIZE);
+        const page2 = pageOf(PAGE_SIZE, PAGE_SIZE);
+        const older = plaudRecording(PAGE_SIZE * 2);
+        const all = [...page1, ...page2, older];
+
+        const getRecordings = vi.fn(async (skip: number) => {
+            if (skip === 0) return { data_file_list: page1 };
+            if (skip === PAGE_SIZE) return { data_file_list: page2 };
+            if (skip === PAGE_SIZE * 2) return { data_file_list: [older] };
+            return { data_file_list: [] };
+        });
+        const getFileDetail = vi.fn();
+
+        (createPlaudClient as Mock).mockResolvedValue({
+            getRecordings,
+            getFileDetail,
+            downloadRecording: vi.fn(),
+        });
+
+        mockSelects({ importPlaudContent: false, recordingsInOrder: all });
+
+        const result = await syncRecordingsForUser(USER_ID);
+
+        expect(result.newRecordings).toBe(0);
+        expect(result.updatedRecordings).toBe(0);
+        expect(getRecordings.mock.calls.map((c) => c[0])).toEqual([
+            0,
+            PAGE_SIZE,
+        ]);
+        expect(getFileDetail).not.toHaveBeenCalled();
+        expect(upsertTranscription).not.toHaveBeenCalled();
+    });
+
+    it("does not call getFileDetail for a version-unchanged row that already has Plaud content", async () => {
+        const rec = plaudRecording(0);
+        const getRecordings = vi.fn(async () => ({
+            data_file_list: [rec],
+        }));
+        const getFileDetail = vi.fn();
+
+        (createPlaudClient as Mock).mockResolvedValue({
+            getRecordings,
+            getFileDetail,
+            downloadRecording: vi.fn(),
+        });
+
+        (db.select as Mock).mockImplementation(() => ({
+            from: (table: unknown) => {
+                const resolve = (rows: unknown[]) => ({
+                    where: () => ({
+                        limit: () => Promise.resolve(rows),
+                    }),
+                });
+                if (table === plaudConnections) {
+                    return resolve([
+                        {
+                            id: "conn-1",
+                            userId: USER_ID,
+                            bearerToken: "encrypted-token",
+                        },
+                    ]);
+                }
+                if (table === userSettings) {
+                    return resolve([{ importPlaudContent: true }]);
+                }
+                if (table === users) {
+                    return resolve([{ email: "test@example.com" }]);
+                }
+                if (table === recordings) {
+                    return resolve([
+                        {
+                            id: "local-plaud-0",
+                            plaudFileId: rec.id,
+                            plaudVersion: "1000",
+                            deletedAt: null,
+                        },
+                    ]);
+                }
+                if (table === transcriptions) {
+                    return resolve([{ id: "existing-plaud-transcript" }]);
+                }
+                if (table === aiEnhancements) {
+                    return resolve([]);
+                }
+                return resolve([]);
+            },
+        }));
+
+        await syncRecordingsForUser(USER_ID);
+
+        expect(getFileDetail).not.toHaveBeenCalled();
+        expect(upsertTranscription).not.toHaveBeenCalled();
+    });
+});

--- a/src/tests/regressions/274-pagination-content-backfill.test.ts
+++ b/src/tests/regressions/274-pagination-content-backfill.test.ts
@@ -1,9 +1,6 @@
 /**
- * Regression for #274: Plaud list pagination stopped after two pages
- * with no new/updated audio, and a version-match skip never built an
- * import candidate. Older recordings therefore never received Plaud
- * transcript/summary backfill. #282's auto-transcribe retry does not
- * cover this path.
+ * Regression for #274: two no-change pages stopped Plaud list pagination,
+ * so older recordings never became content-import candidates.
  */
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
@@ -57,14 +54,7 @@ vi.mock("@/lib/webhooks/emit", () => ({
 }));
 
 import { db } from "@/db";
-import {
-    aiEnhancements,
-    plaudConnections,
-    recordings,
-    transcriptions,
-    userSettings,
-    users,
-} from "@/db/schema";
+import { plaudConnections, recordings, userSettings, users } from "@/db/schema";
 import { createPlaudClient } from "@/lib/plaud/client-factory";
 import { resetAutoTranscribeStateForTests } from "@/lib/sync/auto-transcribe-state";
 import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
@@ -263,67 +253,6 @@ describe("Issue #274 — pagination content backfill", () => {
             0,
             PAGE_SIZE,
         ]);
-        expect(getFileDetail).not.toHaveBeenCalled();
-        expect(upsertTranscription).not.toHaveBeenCalled();
-    });
-
-    it("does not call getFileDetail for a version-unchanged row that already has Plaud content", async () => {
-        const rec = plaudRecording(0);
-        const getRecordings = vi.fn(async () => ({
-            data_file_list: [rec],
-        }));
-        const getFileDetail = vi.fn();
-
-        (createPlaudClient as Mock).mockResolvedValue({
-            getRecordings,
-            getFileDetail,
-            downloadRecording: vi.fn(),
-        });
-
-        (db.select as Mock).mockImplementation(() => ({
-            from: (table: unknown) => {
-                const resolve = (rows: unknown[]) => ({
-                    where: () => ({
-                        limit: () => Promise.resolve(rows),
-                    }),
-                });
-                if (table === plaudConnections) {
-                    return resolve([
-                        {
-                            id: "conn-1",
-                            userId: USER_ID,
-                            bearerToken: "encrypted-token",
-                        },
-                    ]);
-                }
-                if (table === userSettings) {
-                    return resolve([{ importPlaudContent: true }]);
-                }
-                if (table === users) {
-                    return resolve([{ email: "test@example.com" }]);
-                }
-                if (table === recordings) {
-                    return resolve([
-                        {
-                            id: "local-plaud-0",
-                            plaudFileId: rec.id,
-                            plaudVersion: "1000",
-                            deletedAt: null,
-                        },
-                    ]);
-                }
-                if (table === transcriptions) {
-                    return resolve([{ id: "existing-plaud-transcript" }]);
-                }
-                if (table === aiEnhancements) {
-                    return resolve([]);
-                }
-                return resolve([]);
-            },
-        }));
-
-        await syncRecordingsForUser(USER_ID);
-
         expect(getFileDetail).not.toHaveBeenCalled();
         expect(upsertTranscription).not.toHaveBeenCalled();
     });

--- a/src/tests/regressions/274-pagination-content-backfill.test.ts
+++ b/src/tests/regressions/274-pagination-content-backfill.test.ts
@@ -78,6 +78,7 @@ type Fixture = {
     deletedAt?: Date | null;
     hasPlaudTranscript?: boolean;
     hasSummary?: boolean;
+    deviceSn?: string;
 };
 
 function plaudRecording(
@@ -110,6 +111,7 @@ function fixture(
         hasPlaudTranscript?: boolean;
         hasSummary?: boolean;
         is_summary?: boolean;
+        deviceSn?: string;
     } = {},
 ): Fixture {
     return {
@@ -117,22 +119,35 @@ function fixture(
         deletedAt: opts.deletedAt,
         hasPlaudTranscript: opts.hasPlaudTranscript,
         hasSummary: opts.hasSummary,
+        deviceSn: opts.deviceSn,
     };
 }
 
-function findLocalId(clause: unknown): string | undefined {
+function walkStrings(clause: unknown): string[] {
+    const out: string[] = [];
     const seen = new Set<unknown>();
     const stack: unknown[] = [clause];
     while (stack.length > 0) {
         const cur = stack.pop();
         if (cur == null || seen.has(cur)) continue;
-        if (typeof cur === "string" && cur.startsWith("local-")) return cur;
+        if (typeof cur === "string") {
+            out.push(cur);
+            continue;
+        }
         if (typeof cur !== "object") continue;
         seen.add(cur);
         if (Array.isArray(cur)) stack.push(...cur);
         else stack.push(...Object.values(cur as Record<string, unknown>));
     }
-    return undefined;
+    return out;
+}
+
+function collectLocalIds(clause: unknown): Set<string> {
+    return new Set(walkStrings(clause).filter((s) => s.startsWith("local-")));
+}
+
+function findLocalId(clause: unknown): string | undefined {
+    return walkStrings(clause).find((s) => s.startsWith("local-"));
 }
 
 function readyDetail(fileId: string, opts: { summary?: boolean } = {}) {
@@ -178,6 +193,7 @@ function mockSelects(opts: {
     const byLocalId = new Map(
         opts.fixtures.map((f) => [`local-${f.rec.id}`, f]),
     );
+    const plaudFixtures = opts.fixtures.filter((f) => f.deviceSn !== "local");
     let recordingLookup = 0;
 
     (db.select as Mock).mockImplementation(() => {
@@ -217,18 +233,22 @@ function mockSelects(opts: {
                 }
                 if (table === recordings) {
                     if (joined) {
-                        const unseen = opts.fixtures
-                            .slice(recordingLookup)
-                            .find(
-                                (f) =>
-                                    !f.deletedAt &&
-                                    (!f.hasPlaudTranscript || !f.hasSummary),
-                            );
+                        const seenIds = collectLocalIds(whereClause);
+                        const excludeLocalUploads =
+                            walkStrings(whereClause).includes("local");
+                        const unseen = opts.fixtures.find(
+                            (f) =>
+                                (!excludeLocalUploads ||
+                                    f.deviceSn !== "local") &&
+                                !f.deletedAt &&
+                                (!f.hasPlaudTranscript || !f.hasSummary) &&
+                                !seenIds.has(`local-${f.rec.id}`),
+                        );
                         return Promise.resolve(
                             unseen ? [{ id: `local-${unseen.rec.id}` }] : [],
                         );
                     }
-                    const f = opts.fixtures[recordingLookup++];
+                    const f = plaudFixtures[recordingLookup++];
                     if (!f) return Promise.resolve([]);
                     return Promise.resolve([
                         {
@@ -503,5 +523,38 @@ describe("Issue #274 — pagination content backfill", () => {
                 summary: "imported summary",
             }),
         );
+    });
+
+    it("stops after two empty pages when only a local upload still has no content", async () => {
+        const imported = {
+            hasPlaudTranscript: true,
+            hasSummary: true,
+        };
+        const page1 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+            fixture(i, imported),
+        );
+        const page2 = Array.from({ length: PAGE_SIZE }, (_, i) =>
+            fixture(PAGE_SIZE + i, imported),
+        );
+        const older = fixture(PAGE_SIZE * 2, imported);
+        const localUpload = fixture(9999, { deviceSn: "local" });
+        const { getRecordings, getFileDetail } = mockPlaudPages([
+            page1.map((f) => f.rec),
+            page2.map((f) => f.rec),
+            [older.rec],
+        ]);
+        mockSelects({
+            importPlaudContent: true,
+            fixtures: [...page1, ...page2, older, localUpload],
+        });
+
+        await syncRecordingsForUser(USER_ID);
+
+        expect(getRecordings.mock.calls.map((c) => c[0])).toEqual([
+            0,
+            PAGE_SIZE,
+        ]);
+        expect(getFileDetail).not.toHaveBeenCalled();
+        expect(upsertTranscription).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #274

## Proven on current `main` (`e3d885c`)

The bug is still there. #282 retries auto-transcribe only.

**Version-match skip dropped the import candidate**, so `importPlaudContent` only saw new/updated rows. **Two no-change pages stopped the walk** (list is `edit_time` desc). Steady-state sync never reached older files. Plaud can attach transcript/summary without bumping `version_ms`.

## Fix

`src/lib/sync/sync-recordings.ts` only. No auto-transcribe rewrite, no worker.

1. Version-unchanged, non-tombstoned rows become import candidates **only when a local Plaud transcript/summary gap remains**.
2. `importPlaudContent` runs those gap checks **before** `getFileDetail`. Already-imported rows are skipped; an existing Plaud transcript still goes into `transcriptImported` so `plaud_only` keeps suppressing auto-transcription.
3. Two empty pages (no new/updated/candidates) stop a fully-imported run (Plaud transcript **and** enhancement present). If unseen recordings are still missing a Plaud transcript **or** an enhancement, paging continues so an older row behind already-imported recent pages is still reached.
4. Local uploads (`deviceSn = "local"`) are excluded from that unseen-gap scan. They never appear in Plaud pagination, so they must not keep a large account walking to `MAX_PAGES` every sync.

Import off keeps the previous cumulative two-empty-page early-exit.

## Review follow-up

- **Cubic P2 (eaa3c5e / full scan):** closed in `031e917` by candidate-only-on-gap + unseen-gap keep-paging.
- **Cubic P3 (fixtures):** closed in `031e917`.
- **Greptile P2 (getFileDetail before gap check):** closed in `031e917`.
- **Cubic P2 (review 5052742827, transcript present / summary missing):** closed in `5dfe258`. `hasUnseenPlaudContentGaps` treats a missing enhancement as a gap.
- **Cubic P2 (review 5072301859, local uploads force MAX_PAGES):** closed in `6ede7b2`. `ne(recordings.deviceSn, "local")` on the unseen-gap query. Regression: fully-imported Plaud pages plus a local upload with no transcript/summary still stop after two empty pages.
- **Cubic P3 (review 5072301859, seenRecordingIds mock):** closed in `6ede7b2`. Joined recordings mock now excludes IDs actually present in the `notInArray` where clause.

## Testing

- `src/tests/regressions/274-pagination-content-backfill.test.ts` (6 passing)
- `pnpm format-and-lint:fix && pnpm type-check`
- vitest on the #274 file

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7c40332-e6c4-4c6c-aa5f-de6a55e9b23e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7c40332-e6c4-4c6c-aa5f-de6a55e9b23e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #274: Plaud sync was stopping after two pages with no new or updated audio, so older recordings never got transcript and summary backfill when their audio version was unchanged.

- Version-unchanged, non-tombstoned recordings become import candidates only when a Plaud transcript or summary gap remains.
- Paging continues past two no-change pages while Plaud content import is on, as long as an unseen recording still lacks a Plaud transcript or summary; import off keeps the old early exit.
- Local uploads are excluded from that gap check, so large accounts don't scan to MAX_PAGES every sync.
- Existing transcript/summary is checked before fetching Plaud file details, so already-imported rows are not re-fetched.

<sup>Written for commit 6ede7b2d68081cbbf731316f5d4e0063d8eba3c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

