### PR TITLE
fix(transcription): normalize audio and improve diarized output

### DIFF
--- a/src/components/dashboard/recording-player-header.tsx
+++ b/src/components/dashboard/recording-player-header.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { AudioWaveform, Loader2 } from "lucide-react";
+import { LocalTimeRange } from "@/components/local-time";
 import { DownloadAudioButton } from "@/components/recordings/download-audio-button";
 import { RecordingTitle } from "@/components/recordings/recording-title";
 import { CardAction, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatBytes } from "@/lib/format-bytes";
-import { formatDateTime } from "@/lib/format-date";
 import { formatDuration } from "@/lib/format-duration";
 import type { Recording } from "@/types/recording";
 
@@ -24,8 +24,8 @@ interface Props {
  * RecordingPlayer card. Lifted out so the parent's render reads as
  * "header + controls + audio element" instead of a 100-line JSX block.
  *
- * The metadata order is information-density-first: when (relative
- * date), then how long (duration), then how big (file size). Falls
+ * The metadata order is information-density-first: recorded date and
+ * start–end time, then how long (duration), then how big (file size). Falls
  * back to recording.duration / 1000 before the audio element reports
  * a real duration so the line doesn't flicker on first paint.
  */
@@ -38,7 +38,6 @@ export function RecordingPlayerHeader({
     onRenamed,
 }: Props) {
     const metaParts: string[] = [
-        formatDateTime(recording.startTime, "relative"),
         formatDuration(duration || recording.duration / 1000),
         formatBytes(recording.filesize),
     ];
@@ -57,13 +56,18 @@ export function RecordingPlayerHeader({
                 <DownloadAudioButton recordingId={recording.id} />
             </CardAction>
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-                {metaParts.map((part, i) => (
+                <span>
+                    Recorded{" "}
+                    <LocalTimeRange
+                        start={recording.startTime}
+                        durationMs={recording.duration}
+                    />
+                </span>
+                {metaParts.map((part) => (
                     <span key={part} className="inline-flex items-center gap-2">
-                        {i > 0 && (
-                            <span aria-hidden="true" className="opacity-40">
-                                ·
-                            </span>
-                        )}
+                        <span aria-hidden="true" className="opacity-40">
+                            ·
+                        </span>
                         <span>{part}</span>
                     </span>
                 ))}

--- a/src/components/local-time.tsx
+++ b/src/components/local-time.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { formatRecordingDateTimeRange } from "@/lib/format-date";
 
 interface Props {
     /** Date object or anything `new Date(...)` accepts (ISO string, ms). */
@@ -40,6 +41,37 @@ export function LocalTime({ value, variant = "datetime", className }: Props) {
 
     return (
         <time dateTime={iso} className={className}>
+            {text}
+        </time>
+    );
+}
+
+interface LocalTimeRangeProps {
+    start: Date | string | number;
+    durationMs: number;
+    className?: string;
+}
+
+/** Render a recording's absolute local date and start–end time. */
+export function LocalTimeRange({
+    start,
+    durationMs,
+    className,
+}: LocalTimeRangeProps) {
+    const startMs =
+        start instanceof Date ? start.getTime() : new Date(start).getTime();
+    const startDate = new Date(startMs);
+    const endDate = new Date(startDate.getTime() + durationMs);
+    const [text, setText] = useState(
+        `${startDate.toISOString()}–${endDate.toISOString()}`,
+    );
+
+    useEffect(() => {
+        setText(formatRecordingDateTimeRange(new Date(startMs), durationMs));
+    }, [startMs, durationMs]);
+
+    return (
+        <time dateTime={startDate.toISOString()} className={className}>
             {text}
         </time>
     );

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -2,6 +2,7 @@ import {
     differenceInDays,
     format,
     formatDistanceToNow,
+    isSameDay,
     isThisYear,
     isToday,
     isYesterday,
@@ -26,6 +27,21 @@ export function formatDateTime(
         default:
             return formatDistanceToNow(dateObj, { addSuffix: true });
     }
+}
+
+/** Absolute local date and start–end time for a recording. */
+export function formatRecordingDateTimeRange(
+    start: Date | string,
+    durationMs: number,
+): string {
+    const startDate = typeof start === "string" ? new Date(start) : start;
+    const endDate = new Date(startDate.getTime() + durationMs);
+
+    if (isSameDay(startDate, endDate)) {
+        return `${format(startDate, "MMM d, yyyy · h:mm a")}–${format(endDate, "h:mm a")}`;
+    }
+
+    return `${format(startDate, "MMM d, yyyy · h:mm a")}–${format(endDate, "MMM d, yyyy · h:mm a")}`;
 }
 
 /** Recording-list group label: Today / Yesterday / This week / month / Month YYYY. */

--- a/src/lib/transcription/ffmpeg.ts
+++ b/src/lib/transcription/ffmpeg.ts
@@ -1,4 +1,7 @@
 import { spawn } from "node:child_process";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 export function runFfmpeg(
     input: Buffer,
@@ -87,38 +90,48 @@ export function transcodeToMp3(input: Buffer): Promise<Buffer> {
     return runFfmpeg(input, mp3Args());
 }
 
-/** Extract a time range and encode it as mono 16 kHz MP3. */
-export function transcodeSegmentToMp3(
+/** Encode audio into mono 16 kHz MP3 segments in one ffmpeg pass. */
+export async function transcodeToMp3Segments(
     input: Buffer,
-    startSeconds: number,
-    durationSeconds: number,
-): Promise<Buffer> {
-    return runFfmpeg(input, [
-        "-hide_banner",
-        "-loglevel",
-        "error",
-        "-i",
-        "pipe:0",
-        "-ss",
-        startSeconds.toFixed(3),
-        "-t",
-        durationSeconds.toFixed(3),
-        ...mp3OutputArgs(),
-    ]);
+    segmentSeconds: number,
+): Promise<Buffer[]> {
+    const workDir = await mkdtemp(join(tmpdir(), "riffado-diarize-"));
+    try {
+        const outputPattern = join(workDir, "part-%06d.mp3");
+        await runFfmpeg(input, [
+            ...ffmpegInputArgs(),
+            ...mp3EncodingArgs(),
+            "-f",
+            "segment",
+            "-segment_time",
+            segmentSeconds.toFixed(3),
+            "-reset_timestamps",
+            "1",
+            outputPattern,
+        ]);
+        const filenames = (await readdir(workDir))
+            .filter((name) => name.endsWith(".mp3"))
+            .sort();
+        if (filenames.length === 0) {
+            throw new Error("ffmpeg produced no MP3 segments");
+        }
+        return Promise.all(
+            filenames.map((name) => readFile(join(workDir, name))),
+        );
+    } finally {
+        await rm(workDir, { recursive: true, force: true });
+    }
 }
 
 function mp3Args(): string[] {
-    return [
-        "-hide_banner",
-        "-loglevel",
-        "error",
-        "-i",
-        "pipe:0",
-        ...mp3OutputArgs(),
-    ];
+    return [...ffmpegInputArgs(), ...mp3EncodingArgs(), "-f", "mp3", "pipe:1"];
 }
 
-function mp3OutputArgs(): string[] {
+function ffmpegInputArgs(): string[] {
+    return ["-hide_banner", "-loglevel", "error", "-i", "pipe:0"];
+}
+
+function mp3EncodingArgs(): string[] {
     return [
         "-map",
         "0:a:0",
@@ -133,8 +146,5 @@ function mp3OutputArgs(): string[] {
         "libmp3lame",
         "-b:a",
         "64k",
-        "-f",
-        "mp3",
-        "pipe:1",
     ];
 }

--- a/src/lib/transcription/ffmpeg.ts
+++ b/src/lib/transcription/ffmpeg.ts
@@ -84,12 +84,44 @@ export function ffmpegToOpus(
 
 /** Mono 16 kHz MP3 for chat-style providers that reject Ogg/Opus. */
 export function transcodeToMp3(input: Buffer): Promise<Buffer> {
+    return runFfmpeg(input, mp3Args());
+}
+
+/** Extract a time range and encode it as mono 16 kHz MP3. */
+export function transcodeSegmentToMp3(
+    input: Buffer,
+    startSeconds: number,
+    durationSeconds: number,
+): Promise<Buffer> {
     return runFfmpeg(input, [
         "-hide_banner",
         "-loglevel",
         "error",
         "-i",
         "pipe:0",
+        "-ss",
+        startSeconds.toFixed(3),
+        "-t",
+        durationSeconds.toFixed(3),
+        ...mp3OutputArgs(),
+    ]);
+}
+
+function mp3Args(): string[] {
+    return [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        "pipe:0",
+        ...mp3OutputArgs(),
+    ];
+}
+
+function mp3OutputArgs(): string[] {
+    return [
+        "-map",
+        "0:a:0",
         "-vn",
         "-map_metadata",
         "-1",
@@ -104,5 +136,5 @@ export function transcodeToMp3(input: Buffer): Promise<Buffer> {
         "-f",
         "mp3",
         "pipe:1",
-    ]);
+    ];
 }

--- a/src/lib/transcription/openai-diarized-transcribe.ts
+++ b/src/lib/transcription/openai-diarized-transcribe.ts
@@ -1,0 +1,100 @@
+import type { OpenAI } from "openai";
+import type { TranscriptionDiarized } from "openai/resources/audio/transcriptions";
+import {
+    transcodeSegmentToMp3,
+    transcodeToMp3,
+} from "@/lib/transcription/ffmpeg";
+import { buildTranscriptionParams } from "@/lib/transcription/format";
+
+// OpenAI currently rejects diarization chunks over 1,400 seconds. Leave a
+// margin for container timestamps and provider-side chunk boundary changes.
+const MAX_CHUNK_SECONDS = 20 * 60;
+
+interface DiarizedTranscriptionOptions {
+    client: OpenAI;
+    model: string;
+    audioBuffer: Buffer;
+    durationMs: number;
+    filename: string;
+    language?: string;
+    timeoutMs: number;
+}
+
+/** Normalize and locally chunk audio before calling OpenAI's diarization API. */
+export async function transcribeOpenAIDiarized(
+    options: DiarizedTranscriptionOptions,
+): Promise<{ text: string; detectedLanguage: null }> {
+    const {
+        client,
+        model,
+        audioBuffer,
+        durationMs,
+        filename,
+        language,
+        timeoutMs,
+    } = options;
+    const durationSeconds = durationMs / 1000;
+    const chunkCount = Math.max(
+        1,
+        Math.ceil(durationSeconds / MAX_CHUNK_SECONDS),
+    );
+    const chunkDuration = durationSeconds / chunkCount;
+    const responses: TranscriptionDiarized[] = [];
+
+    for (let index = 0; index < chunkCount; index += 1) {
+        const mp3 =
+            chunkCount === 1
+                ? await transcodeToMp3(audioBuffer)
+                : await transcodeSegmentToMp3(
+                      audioBuffer,
+                      index * chunkDuration,
+                      chunkDuration,
+                  );
+        const file = buildMp3File(mp3, filename, index, chunkCount);
+        const response = await client.audio.transcriptions.create(
+            buildTranscriptionParams({
+                file,
+                model,
+                responseFormat: "diarized_json",
+                language,
+            }),
+            { timeout: timeoutMs },
+        );
+        responses.push(response as TranscriptionDiarized);
+    }
+
+    return {
+        text: formatDiarizedResponses(responses),
+        detectedLanguage: null,
+    };
+}
+
+function buildMp3File(
+    buffer: Buffer,
+    filename: string,
+    index: number,
+    chunkCount: number,
+): File {
+    const stem = filename.replace(/\.[^.]+$/, "");
+    const suffix = chunkCount > 1 ? `-part-${index + 1}` : "";
+    const view = new Uint8Array(
+        buffer.buffer as ArrayBuffer,
+        buffer.byteOffset,
+        buffer.byteLength,
+    );
+    return new File([view], `${stem}${suffix}.mp3`, { type: "audio/mpeg" });
+}
+
+function formatDiarizedResponses(responses: TranscriptionDiarized[]): string {
+    const multipleParts = responses.length > 1;
+    return responses
+        .flatMap((response, index) =>
+            (response.segments ?? []).map((segment) => {
+                const speaker = multipleParts
+                    ? `part_${index + 1}_${segment.speaker}`
+                    : segment.speaker;
+                return `${speaker}: ${segment.text}`;
+            }),
+        )
+        .join("\n");
+}

--- a/src/lib/transcription/openai-diarized-transcribe.ts
+++ b/src/lib/transcription/openai-diarized-transcribe.ts
@@ -1,8 +1,8 @@
 import type { OpenAI } from "openai";
 import type { TranscriptionDiarized } from "openai/resources/audio/transcriptions";
 import {
-    transcodeSegmentToMp3,
     transcodeToMp3,
+    transcodeToMp3Segments,
 } from "@/lib/transcription/ffmpeg";
 import { buildTranscriptionParams } from "@/lib/transcription/format";
 
@@ -39,18 +39,14 @@ export async function transcribeOpenAIDiarized(
         Math.ceil(durationSeconds / MAX_CHUNK_SECONDS),
     );
     const chunkDuration = durationSeconds / chunkCount;
+    const mp3Chunks =
+        chunkCount === 1
+            ? [await transcodeToMp3(audioBuffer)]
+            : await transcodeToMp3Segments(audioBuffer, chunkDuration);
     const responses: TranscriptionDiarized[] = [];
 
-    for (let index = 0; index < chunkCount; index += 1) {
-        const mp3 =
-            chunkCount === 1
-                ? await transcodeToMp3(audioBuffer)
-                : await transcodeSegmentToMp3(
-                      audioBuffer,
-                      index * chunkDuration,
-                      chunkDuration,
-                  );
-        const file = buildMp3File(mp3, filename, index, chunkCount);
+    for (const [index, mp3] of mp3Chunks.entries()) {
+        const file = buildMp3File(mp3, filename, index, mp3Chunks.length);
         const response = await client.audio.transcriptions.create(
             buildTranscriptionParams({
                 file,

--- a/src/lib/transcription/openai-diarized-transcribe.ts
+++ b/src/lib/transcription/openai-diarized-transcribe.ts
@@ -83,14 +83,57 @@ function buildMp3File(
 
 function formatDiarizedResponses(responses: TranscriptionDiarized[]): string {
     const multipleParts = responses.length > 1;
-    return responses
-        .flatMap((response, index) =>
-            (response.segments ?? []).map((segment) => {
-                const speaker = multipleParts
-                    ? `part_${index + 1}_${segment.speaker}`
-                    : segment.speaker;
-                return `${speaker}: ${segment.text}`;
-            }),
-        )
-        .join("\n");
+    const formattedTurns: string[] = [];
+    let timeOffsetSeconds = 0;
+
+    for (const [partIndex, response] of responses.entries()) {
+        const speakerNumbers = new Map<string, number>();
+        const turns: Array<{
+            speaker: string;
+            start: number;
+            text: string;
+        }> = [];
+
+        for (const segment of response.segments ?? []) {
+            const previous = turns.at(-1);
+            if (previous?.speaker === segment.speaker) {
+                previous.text = `${previous.text} ${segment.text.trim()}`;
+            } else {
+                turns.push({
+                    speaker: segment.speaker,
+                    start: segment.start,
+                    text: segment.text.trim(),
+                });
+            }
+        }
+
+        for (const turn of turns) {
+            let speakerNumber = speakerNumbers.get(turn.speaker);
+            if (speakerNumber === undefined) {
+                speakerNumber = speakerNumbers.size + 1;
+                speakerNumbers.set(turn.speaker, speakerNumber);
+            }
+            const partLabel = multipleParts ? ` · Part ${partIndex + 1}` : "";
+            formattedTurns.push(
+                `[${formatTimestamp(timeOffsetSeconds + turn.start)}] Speaker ${speakerNumber}${partLabel}\n${turn.text}`,
+            );
+        }
+
+        timeOffsetSeconds += response.duration;
+    }
+
+    return formattedTurns.join("\n\n");
+}
+
+function formatTimestamp(seconds: number): string {
+    const wholeSeconds = Math.max(0, Math.floor(seconds));
+    const hours = Math.floor(wholeSeconds / 3600);
+    const minutes = Math.floor((wholeSeconds % 3600) / 60);
+    const remainingSeconds = wholeSeconds % 60;
+    const minuteText = String(minutes).padStart(2, "0");
+    const secondText = String(remainingSeconds).padStart(2, "0");
+
+    return hours > 0
+        ? `${String(hours).padStart(2, "0")}:${minuteText}:${secondText}`
+        : `${minuteText}:${secondText}`;
 }

--- a/src/lib/transcription/transcribe-recording.ts
+++ b/src/lib/transcription/transcribe-recording.ts
@@ -37,6 +37,7 @@ import {
 } from "@/lib/transcription/format";
 import { geminiTranscribe } from "@/lib/transcription/gemini-transcribe";
 import { isRiffadoIncludedProviderId } from "@/lib/transcription/included-provider";
+import { transcribeOpenAIDiarized } from "@/lib/transcription/openai-diarized-transcribe";
 import { upsertTranscription } from "@/lib/transcription/persist";
 import { emitEvent } from "@/lib/webhooks/emit";
 
@@ -472,43 +473,57 @@ async function transcribeRecordingInner(
                 } else {
                     const responseFormat = getResponseFormat(model);
 
-                    // OpenAI's /v1/audio/transcriptions endpoint has a hard
-                    // 25 MiB per-request limit. For meeting-length recordings
-                    // that limit is the common case, not the edge case -- fall
-                    // back to a mono Opus re-encode so 3 h+ uploads don't get
-                    // rejected with a 413.
-                    const compressed = await maybeCompressForWhisper(
-                        audioBuffer,
-                        contentType,
-                    );
-                    const fileToSend = compressed.compressed
-                        ? buildAudioFile(
-                              compressed.buffer,
-                              recording.storagePath,
-                              decryptedFilename,
-                          ).file
-                        : audioFile;
-
-                    // Whisper-1 runs ~0.1-0.3x realtime, so a 3 h recording
-                    // can keep the request open 20-40 min. The SDK default
-                    // (10 min) times out long before that; override
-                    // per-request so other OpenAI calls keep the default.
-                    const transcription =
-                        await openai.audio.transcriptions.create(
-                            buildTranscriptionParams({
-                                file: fileToSend,
-                                model,
-                                responseFormat,
-                                language: defaultLanguage,
-                            }),
-                            { timeout: env.WHISPER_REQUEST_TIMEOUT_MS },
+                    if (responseFormat === "diarized_json") {
+                        const parsed = await transcribeOpenAIDiarized({
+                            client: openai,
+                            model,
+                            audioBuffer,
+                            durationMs: recording.duration,
+                            filename: decryptedFilename,
+                            language: defaultLanguage,
+                            timeoutMs: env.WHISPER_REQUEST_TIMEOUT_MS,
+                        });
+                        transcriptionText = parsed.text;
+                        detectedLanguage = parsed.detectedLanguage;
+                    } else {
+                        // OpenAI's /v1/audio/transcriptions endpoint has a hard
+                        // 25 MiB per-request limit. For meeting-length recordings
+                        // that limit is the common case, not the edge case -- fall
+                        // back to a mono Opus re-encode so 3 h+ uploads don't get
+                        // rejected with a 413.
+                        const compressed = await maybeCompressForWhisper(
+                            audioBuffer,
+                            contentType,
                         );
-                    const parsed = parseTranscriptionResponse(
-                        transcription,
-                        responseFormat,
-                    );
-                    transcriptionText = parsed.text;
-                    detectedLanguage = parsed.detectedLanguage;
+                        const fileToSend = compressed.compressed
+                            ? buildAudioFile(
+                                  compressed.buffer,
+                                  recording.storagePath,
+                                  decryptedFilename,
+                              ).file
+                            : audioFile;
+
+                        // Whisper-1 runs ~0.1-0.3x realtime, so a 3 h recording
+                        // can keep the request open 20-40 min. The SDK default
+                        // (10 min) times out long before that; override
+                        // per-request so other OpenAI calls keep the default.
+                        const transcription =
+                            await openai.audio.transcriptions.create(
+                                buildTranscriptionParams({
+                                    file: fileToSend,
+                                    model,
+                                    responseFormat,
+                                    language: defaultLanguage,
+                                }),
+                                { timeout: env.WHISPER_REQUEST_TIMEOUT_MS },
+                            );
+                        const parsed = parseTranscriptionResponse(
+                            transcription,
+                            responseFormat,
+                        );
+                        transcriptionText = parsed.text;
+                        detectedLanguage = parsed.detectedLanguage;
+                    }
                 }
             }
         } else {

--- a/src/tests/format-date.test.ts
+++ b/src/tests/format-date.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatRecordingDateTimeRange } from "@/lib/format-date";
+
+describe("formatRecordingDateTimeRange", () => {
+    it("shows the recorded date with start and end times", () => {
+        const start = new Date(2026, 8, 7, 11, 27);
+
+        expect(formatRecordingDateTimeRange(start, 25 * 60 * 1000)).toBe(
+            "Sep 7, 2026 · 11:27 AM–11:52 AM",
+        );
+    });
+
+    it("shows both dates when a recording crosses midnight", () => {
+        const start = new Date(2026, 8, 7, 23, 50);
+
+        expect(formatRecordingDateTimeRange(start, 20 * 60 * 1000)).toBe(
+            "Sep 7, 2026 · 11:50 PM–Sep 8, 2026 · 12:10 AM",
+        );
+    });
+});

--- a/src/tests/regressions/101-diarize-chunking-strategy.test.ts
+++ b/src/tests/regressions/101-diarize-chunking-strategy.test.ts
@@ -164,6 +164,13 @@ vi.mock("@/lib/plaud/client-factory", () => ({
     createPlaudClient: vi.fn(),
 }));
 
+vi.mock("@/lib/transcription/ffmpeg", () => ({
+    transcodeSegmentToMp3: vi
+        .fn()
+        .mockResolvedValue(Buffer.from("fake-mp3-chunk")),
+    transcodeToMp3: vi.fn().mockResolvedValue(Buffer.from("fake-mp3-bytes")),
+}));
+
 import { OpenAI } from "openai";
 import { db } from "@/db";
 import { transcribeRecording } from "@/lib/transcription/transcribe-recording";
@@ -186,6 +193,7 @@ describe("issue #101 — transcribeRecording sends chunking_strategy for diarize
             plaudFileId: "plaud-1",
             filename: "Some Recording",
             storagePath: "rec-101.mp3",
+            duration: 60_000,
             deletedAt: null,
         };
         const credsRow = {

--- a/src/tests/regressions/101-diarize-chunking-strategy.test.ts
+++ b/src/tests/regressions/101-diarize-chunking-strategy.test.ts
@@ -165,10 +165,10 @@ vi.mock("@/lib/plaud/client-factory", () => ({
 }));
 
 vi.mock("@/lib/transcription/ffmpeg", () => ({
-    transcodeSegmentToMp3: vi
-        .fn()
-        .mockResolvedValue(Buffer.from("fake-mp3-chunk")),
     transcodeToMp3: vi.fn().mockResolvedValue(Buffer.from("fake-mp3-bytes")),
+    transcodeToMp3Segments: vi
+        .fn()
+        .mockResolvedValue([Buffer.from("fake-mp3-chunk")]),
 }));
 
 import { OpenAI } from "openai";

--- a/src/tests/regressions/160-plaud-ogg-opus.test.ts
+++ b/src/tests/regressions/160-plaud-ogg-opus.test.ts
@@ -86,7 +86,11 @@ import { createUserStorageProvider } from "@/lib/storage/factory";
 import { syncRecordingsForUser } from "@/lib/sync/sync-recordings";
 import { buildAudioFile } from "@/lib/transcription/audio-file";
 import { chatTranscribe } from "@/lib/transcription/chat-transcribe";
-import { ffmpegToOpus, transcodeToMp3 } from "@/lib/transcription/ffmpeg";
+import {
+    ffmpegToOpus,
+    transcodeToMp3,
+    transcodeToMp3Segments,
+} from "@/lib/transcription/ffmpeg";
 
 const FIXTURE = path.join(__dirname, "..", "fixtures", "sample.mp3");
 
@@ -402,6 +406,21 @@ describe("issue #160 — Plaud .mp3 that is actually Ogg/Opus", () => {
             const mp3 = await transcodeToMp3(ogg);
             expect(sniffAudio(mp3).container).toBe("mp3");
             expect(mp3.length).toBeGreaterThan(0);
+        },
+        15_000,
+    );
+
+    itIfFfmpeg(
+        "transcodeToMp3Segments writes multiple MPEG streams in one pass",
+        async () => {
+            const fixture = await readFile(FIXTURE);
+            const segments = await transcodeToMp3Segments(fixture, 0.4);
+
+            expect(segments.length).toBeGreaterThan(1);
+            for (const segment of segments) {
+                expect(sniffAudio(segment).container).toBe("mp3");
+                expect(segment.length).toBeGreaterThan(0);
+            }
         },
         15_000,
     );

--- a/src/tests/regressions/291-openai-diarization-audio.test.ts
+++ b/src/tests/regressions/291-openai-diarization-audio.test.ts
@@ -9,14 +9,14 @@
 import type { OpenAI } from "openai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { transcodeSegmentToMp3, transcodeToMp3 } = vi.hoisted(() => ({
-    transcodeSegmentToMp3: vi.fn(),
+const { transcodeToMp3, transcodeToMp3Segments } = vi.hoisted(() => ({
     transcodeToMp3: vi.fn(),
+    transcodeToMp3Segments: vi.fn(),
 }));
 
 vi.mock("@/lib/transcription/ffmpeg", () => ({
-    transcodeSegmentToMp3,
     transcodeToMp3,
+    transcodeToMp3Segments,
 }));
 
 import { transcribeOpenAIDiarized } from "@/lib/transcription/openai-diarized-transcribe";
@@ -31,10 +31,10 @@ describe("issue #291 — OpenAI diarization audio preparation", () => {
     beforeEach(() => {
         vi.clearAllMocks();
         transcodeToMp3.mockResolvedValue(Buffer.from("normalized-mp3"));
-        transcodeSegmentToMp3.mockImplementation(
-            async (_input: Buffer, startSeconds: number) =>
-                Buffer.from(`chunk-${startSeconds}`),
-        );
+        transcodeToMp3Segments.mockResolvedValue([
+            Buffer.from("chunk-1"),
+            Buffer.from("chunk-2"),
+        ]);
     });
 
     it("normalizes a short recording to MP3 before transcription", async () => {
@@ -52,7 +52,7 @@ describe("issue #291 — OpenAI diarization audio preparation", () => {
         });
 
         expect(transcodeToMp3).toHaveBeenCalledWith(audioBuffer);
-        expect(transcodeSegmentToMp3).not.toHaveBeenCalled();
+        expect(transcodeToMp3Segments).not.toHaveBeenCalled();
         expect(create).toHaveBeenCalledTimes(1);
         const params = create.mock.calls[0]?.[0];
         expect(params.file).toMatchObject({
@@ -83,16 +83,9 @@ describe("issue #291 — OpenAI diarization audio preparation", () => {
             timeoutMs: 10_000,
         });
 
-        expect(transcodeSegmentToMp3).toHaveBeenNthCalledWith(
-            1,
+        expect(transcodeToMp3Segments).toHaveBeenCalledOnce();
+        expect(transcodeToMp3Segments).toHaveBeenCalledWith(
             audioBuffer,
-            0,
-            741.96,
-        );
-        expect(transcodeSegmentToMp3).toHaveBeenNthCalledWith(
-            2,
-            audioBuffer,
-            741.96,
             741.96,
         );
         expect(create).toHaveBeenCalledTimes(2);
@@ -109,6 +102,12 @@ describe("issue #291 — OpenAI diarization audio preparation", () => {
     });
 
     it("keeps every generated chunk at or below 20 minutes", async () => {
+        transcodeToMp3Segments.mockResolvedValue([
+            Buffer.from("chunk-1"),
+            Buffer.from("chunk-2"),
+            Buffer.from("chunk-3"),
+            Buffer.from("chunk-4"),
+        ]);
         create.mockResolvedValue({ segments: [] });
 
         await transcribeOpenAIDiarized({
@@ -120,10 +119,10 @@ describe("issue #291 — OpenAI diarization audio preparation", () => {
             timeoutMs: 10_000,
         });
 
-        expect(transcodeSegmentToMp3).toHaveBeenCalledTimes(4);
-        const durations = transcodeSegmentToMp3.mock.calls.map(
-            (call) => call[2] as number,
+        expect(transcodeToMp3Segments).toHaveBeenCalledOnce();
+        expect(transcodeToMp3Segments.mock.calls[0]?.[1]).toBeLessThanOrEqual(
+            20 * 60,
         );
-        expect(durations.every((duration) => duration <= 20 * 60)).toBe(true);
+        expect(create).toHaveBeenCalledTimes(4);
     });
 });

--- a/src/tests/regressions/291-openai-diarization-audio.test.ts
+++ b/src/tests/regressions/291-openai-diarization-audio.test.ts
@@ -39,7 +39,12 @@ describe("issue #291 — OpenAI diarization audio preparation", () => {
 
     it("normalizes a short recording to MP3 before transcription", async () => {
         create.mockResolvedValue({
-            segments: [{ speaker: "speaker_0", text: "Hello" }],
+            duration: 60,
+            segments: [
+                { speaker: "A", start: 2.4, text: "Hello" },
+                { speaker: "A", start: 4.8, text: "again" },
+                { speaker: "B", start: 8.1, text: "Hi there" },
+            ],
         });
 
         const result = await transcribeOpenAIDiarized({
@@ -61,16 +66,20 @@ describe("issue #291 — OpenAI diarization audio preparation", () => {
         });
         expect(params.response_format).toBe("diarized_json");
         expect(params.chunking_strategy).toBe("auto");
-        expect(result.text).toBe("speaker_0: Hello");
+        expect(result.text).toBe(
+            "[00:02] Speaker 1\nHello again\n\n[00:08] Speaker 2\nHi there",
+        );
     });
 
     it("splits a 1,483 second recording into balanced sub-limit chunks", async () => {
         create
             .mockResolvedValueOnce({
-                segments: [{ speaker: "speaker_0", text: "First" }],
+                duration: 741.96,
+                segments: [{ speaker: "A", start: 0, text: "First" }],
             })
             .mockResolvedValueOnce({
-                segments: [{ speaker: "speaker_0", text: "Second" }],
+                duration: 741.96,
+                segments: [{ speaker: "A", start: 8.04, text: "Second" }],
             });
 
         const result = await transcribeOpenAIDiarized({
@@ -97,7 +106,7 @@ describe("issue #291 — OpenAI diarization audio preparation", () => {
         );
         expect(create.mock.calls[0]?.[0].language).toBe("en");
         expect(result.text).toBe(
-            "part_1_speaker_0: First\npart_2_speaker_0: Second",
+            "[00:00] Speaker 1 · Part 1\nFirst\n\n[12:30] Speaker 1 · Part 2\nSecond",
         );
     });
 
@@ -108,7 +117,7 @@ describe("issue #291 — OpenAI diarization audio preparation", () => {
             Buffer.from("chunk-3"),
             Buffer.from("chunk-4"),
         ]);
-        create.mockResolvedValue({ segments: [] });
+        create.mockResolvedValue({ duration: 900.75, segments: [] });
 
         await transcribeOpenAIDiarized({
             client,

--- a/src/tests/regressions/291-openai-diarization-audio.test.ts
+++ b/src/tests/regressions/291-openai-diarization-audio.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression: issue #291
+ *
+ * Plaud Ogg/Opus recordings can be rejected by OpenAI's diarization model even
+ * when the container is valid, and the provider rejects any generated chunk
+ * longer than 1,400 seconds. Riffado now normalizes diarization input to MP3
+ * and splits long recordings into balanced chunks of at most 20 minutes.
+ */
+import type { OpenAI } from "openai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { transcodeSegmentToMp3, transcodeToMp3 } = vi.hoisted(() => ({
+    transcodeSegmentToMp3: vi.fn(),
+    transcodeToMp3: vi.fn(),
+}));
+
+vi.mock("@/lib/transcription/ffmpeg", () => ({
+    transcodeSegmentToMp3,
+    transcodeToMp3,
+}));
+
+import { transcribeOpenAIDiarized } from "@/lib/transcription/openai-diarized-transcribe";
+
+describe("issue #291 — OpenAI diarization audio preparation", () => {
+    const audioBuffer = Buffer.from("plaud-ogg-opus");
+    const create = vi.fn();
+    const client = {
+        audio: { transcriptions: { create } },
+    } as unknown as OpenAI;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        transcodeToMp3.mockResolvedValue(Buffer.from("normalized-mp3"));
+        transcodeSegmentToMp3.mockImplementation(
+            async (_input: Buffer, startSeconds: number) =>
+                Buffer.from(`chunk-${startSeconds}`),
+        );
+    });
+
+    it("normalizes a short recording to MP3 before transcription", async () => {
+        create.mockResolvedValue({
+            segments: [{ speaker: "speaker_0", text: "Hello" }],
+        });
+
+        const result = await transcribeOpenAIDiarized({
+            client,
+            model: "gpt-4o-transcribe-diarize",
+            audioBuffer,
+            durationMs: 60_000,
+            filename: "meeting.ogg",
+            timeoutMs: 10_000,
+        });
+
+        expect(transcodeToMp3).toHaveBeenCalledWith(audioBuffer);
+        expect(transcodeSegmentToMp3).not.toHaveBeenCalled();
+        expect(create).toHaveBeenCalledTimes(1);
+        const params = create.mock.calls[0]?.[0];
+        expect(params.file).toMatchObject({
+            name: "meeting.mp3",
+            type: "audio/mpeg",
+        });
+        expect(params.response_format).toBe("diarized_json");
+        expect(params.chunking_strategy).toBe("auto");
+        expect(result.text).toBe("speaker_0: Hello");
+    });
+
+    it("splits a 1,483 second recording into balanced sub-limit chunks", async () => {
+        create
+            .mockResolvedValueOnce({
+                segments: [{ speaker: "speaker_0", text: "First" }],
+            })
+            .mockResolvedValueOnce({
+                segments: [{ speaker: "speaker_0", text: "Second" }],
+            });
+
+        const result = await transcribeOpenAIDiarized({
+            client,
+            model: "gpt-4o-transcribe-diarize",
+            audioBuffer,
+            durationMs: 1_483_920,
+            filename: "long-meeting.ogg",
+            language: "en",
+            timeoutMs: 10_000,
+        });
+
+        expect(transcodeSegmentToMp3).toHaveBeenNthCalledWith(
+            1,
+            audioBuffer,
+            0,
+            741.96,
+        );
+        expect(transcodeSegmentToMp3).toHaveBeenNthCalledWith(
+            2,
+            audioBuffer,
+            741.96,
+            741.96,
+        );
+        expect(create).toHaveBeenCalledTimes(2);
+        expect(create.mock.calls[0]?.[0].file.name).toBe(
+            "long-meeting-part-1.mp3",
+        );
+        expect(create.mock.calls[1]?.[0].file.name).toBe(
+            "long-meeting-part-2.mp3",
+        );
+        expect(create.mock.calls[0]?.[0].language).toBe("en");
+        expect(result.text).toBe(
+            "part_1_speaker_0: First\npart_2_speaker_0: Second",
+        );
+    });
+
+    it("keeps every generated chunk at or below 20 minutes", async () => {
+        create.mockResolvedValue({ segments: [] });
+
+        await transcribeOpenAIDiarized({
+            client,
+            model: "gpt-4o-transcribe-diarize",
+            audioBuffer,
+            durationMs: 3_603_000,
+            filename: "one-hour-recording.ogg",
+            timeoutMs: 10_000,
+        });
+
+        expect(transcodeSegmentToMp3).toHaveBeenCalledTimes(4);
+        const durations = transcodeSegmentToMp3.mock.calls.map(
+            (call) => call[2] as number,
+        );
+        expect(durations.every((duration) => duration <= 20 * 60)).toBe(true);
+    });
+});


### PR DESCRIPTION
Plaud Ogg/Opus recordings could reach OpenAI's diarization endpoint with a valid but provider-incompatible container, producing `Audio file might be corrupted or unsupported`. Long recordings could also fail when OpenAI's automatic diarization produced a chunk over the model's 1,400-second limit.

This change:

- normalizes diarization input to mono 16 kHz MP3 and explicitly selects the first audio stream, dropping Plaud's auxiliary vendor stream
- splits recordings into balanced chunks of at most 20 minutes in one ffmpeg pass before sending them sequentially
- formats diarized output as timestamped `Speaker 1`, `Speaker 2`, etc. turns with blank lines between speakers
- offsets timestamps onto the full recording timeline and marks part boundaries when multiple requests are merged, since speaker identities are not stable across independent diarization calls
- shows the recording's absolute local date and start–end time in the player header
- leaves existing Whisper and plain GPT transcription paths unchanged

Fixes #291

Validation:

- `pnpm format-and-lint:fix`
- `pnpm type-check`
- `pnpm test` (132 files passed, 4 skipped; 965 tests passed, 10 skipped)
