### PR TITLE
feat(ui): render Plaud summaries as markdown and transcripts by speaker

### DIFF
--- a/src/components/dashboard/transcription-panel.tsx
+++ b/src/components/dashboard/transcription-panel.tsx
@@ -13,6 +13,10 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { TranscribeInBrowserButton } from "@/components/dashboard/transcribe-in-browser-button";
+import {
+    RichMarkdown,
+    SpeakerTranscript,
+} from "@/components/recordings/rich-content";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -184,10 +188,10 @@ export function TranscriptionPanel({
                                     ))}
                                 </div>
                             )}
-                            <div className="bg-muted rounded-lg p-4 max-h-96 overflow-y-auto">
-                                <p className="text-sm whitespace-pre-wrap leading-relaxed">
-                                    {activeTranscript.text}
-                                </p>
+                            <div className="bg-muted rounded-lg p-4 max-h-96 overflow-y-auto text-sm">
+                                <SpeakerTranscript
+                                    text={activeTranscript.text}
+                                />
                             </div>
                             <div className="flex items-center gap-4 text-xs text-muted-foreground pt-2 border-t">
                                 <span className="px-2 py-0.5 rounded bg-muted font-medium">
@@ -319,10 +323,10 @@ export function TranscriptionPanel({
                                 {summaryExpanded && (
                                     <div className="space-y-4">
                                         {/* Summary text */}
-                                        <div className="bg-muted rounded-lg p-4">
-                                            <p className="text-sm leading-relaxed">
-                                                {summaryData.summary}
-                                            </p>
+                                        <div className="bg-muted rounded-lg p-4 text-sm">
+                                            <RichMarkdown
+                                                content={summaryData.summary}
+                                            />
                                         </div>
 
                                         {/* Key points */}

--- a/src/components/recordings/rich-content.tsx
+++ b/src/components/recordings/rich-content.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import type { JSX, ReactNode } from "react";
+
+function isSafeImageSrc(src: string): boolean {
+    return src.startsWith("/api/plaud-assets/") || src.startsWith("https://");
+}
+
+// Inline markdown: bold, italic, inline code, strikethrough, and links.
+function renderInline(text: string, keyPrefix: string): ReactNode[] {
+    const nodes: ReactNode[] = [];
+    // Ordered so the first match at a position wins.
+    const pattern =
+        /(\*\*([^*]+)\*\*)|(~~([^~]+)~~)|(`([^`]+)`)|(\*([^*]+)\*)|(_([^_]+)_)|(\[([^\]]+)\]\(([^)]+)\))/g;
+    let last = 0;
+    let m: RegExpExecArray | null;
+    let i = 0;
+    // biome-ignore lint/suspicious/noAssignInExpressions: standard regex loop
+    while ((m = pattern.exec(text)) !== null) {
+        if (m.index > last) nodes.push(text.slice(last, m.index));
+        const k = `${keyPrefix}-i${i++}`;
+        if (m[1]) nodes.push(<strong key={k}>{m[2]}</strong>);
+        else if (m[3])
+            nodes.push(
+                <del key={k} className="opacity-70">
+                    {m[4]}
+                </del>,
+            );
+        else if (m[5])
+            nodes.push(
+                <code
+                    key={k}
+                    className="rounded bg-black/20 px-1 py-0.5 font-mono text-[0.85em]"
+                >
+                    {m[6]}
+                </code>,
+            );
+        else if (m[7]) nodes.push(<em key={k}>{m[8]}</em>);
+        else if (m[9]) nodes.push(<em key={k}>{m[10]}</em>);
+        else if (m[11]) {
+            const href = m[13];
+            const safe = href.startsWith("https://") || href.startsWith("/");
+            nodes.push(
+                safe ? (
+                    <a
+                        key={k}
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-accent-cyan underline underline-offset-2"
+                    >
+                        {m[12]}
+                    </a>
+                ) : (
+                    m[12]
+                ),
+            );
+        }
+        last = pattern.lastIndex;
+    }
+    if (last < text.length) nodes.push(text.slice(last));
+    return nodes;
+}
+
+const HR_RE = /^\s*([-*_])\1{2,}\s*$/; // ---, ***, ___ (3+)
+const IMG_RE = /^!\[([^\]]*)\]\(([^)]+)\)\s*$/;
+const HEADING_RE = /^(#{1,6})\s+(.*)$/;
+const BULLET_RE = /^\s*[-*]\s+(.*)$/;
+const CHECK_RE = /^\s*[-*]\s+\[([ xX])\]\s+(.*)$/;
+const ORDERED_RE = /^\s*\d+[.)]\s+(.*)$/;
+const QUOTE_RE = /^\s*>\s?(.*)$/;
+
+/**
+ * Render the markdown subset Plaud emits in summaries: headings, bold,
+ * italic, strikethrough, inline code, bullet/ordered/checkbox lists,
+ * blockquotes, horizontal rules, links, and images.
+ *
+ * Output is built from React elements, never `dangerouslySetInnerHTML`, so
+ * every text run is auto-escaped. Image sources are restricted to
+ * same-origin asset routes and `https:`, and link hrefs to `https:` and
+ * same-origin paths, so summary content cannot introduce a `data:` or
+ * `javascript:` URL. Anything unrecognised falls through as plain text.
+ */
+export function RichMarkdown({
+    content,
+    className,
+}: {
+    content: string;
+    className?: string;
+}): JSX.Element {
+    const lines = content.replace(/\r\n/g, "\n").split("\n");
+    const blocks: ReactNode[] = [];
+    let para: string[] = [];
+    let list: {
+        ordered: boolean;
+        items: { text: string; check?: boolean }[];
+    } | null = null;
+    let quote: string[] = [];
+    let b = 0;
+
+    const flushPara = () => {
+        if (para.length) {
+            const key = `p${b++}`;
+            blocks.push(
+                <p key={key} className="leading-relaxed my-2">
+                    {renderInline(para.join(" "), key)}
+                </p>,
+            );
+            para = [];
+        }
+    };
+    const flushList = () => {
+        if (list) {
+            const key = `l${b++}`;
+            const items = list.items.map((it, idx) => (
+                <li
+                    // biome-ignore lint/suspicious/noArrayIndexKey: parsed output is rebuilt from scratch on every render and never reordered
+                    key={`${key}-${idx}`}
+                    className="leading-relaxed flex gap-2 items-start"
+                >
+                    {it.check !== undefined && (
+                        <input
+                            type="checkbox"
+                            checked={it.check}
+                            readOnly
+                            className="mt-1.5 shrink-0 accent-accent-cyan"
+                        />
+                    )}
+                    {it.check === undefined && (
+                        <span className="mt-1.5 size-1.5 rounded-full bg-accent-cyan shrink-0" />
+                    )}
+                    <span>{renderInline(it.text, `${key}-${idx}`)}</span>
+                </li>
+            ));
+            blocks.push(
+                list.ordered ? (
+                    <ol key={key} className="my-2 space-y-1 list-decimal pl-5">
+                        {items}
+                    </ol>
+                ) : (
+                    <ul key={key} className="my-2 space-y-1">
+                        {items}
+                    </ul>
+                ),
+            );
+            list = null;
+        }
+    };
+    const flushQuote = () => {
+        if (quote.length) {
+            const key = `q${b++}`;
+            blocks.push(
+                <blockquote
+                    key={key}
+                    className="my-2 border-l-2 border-accent-cyan/60 pl-3 italic text-muted-foreground"
+                >
+                    {renderInline(quote.join(" "), key)}
+                </blockquote>,
+            );
+            quote = [];
+        }
+    };
+    const flushAll = () => {
+        flushPara();
+        flushList();
+        flushQuote();
+    };
+
+    for (const raw of lines) {
+        const line = raw.trimEnd();
+        if (!line.trim()) {
+            flushAll();
+            continue;
+        }
+
+        const img = line.match(IMG_RE);
+        if (img && isSafeImageSrc(img[2])) {
+            flushAll();
+            blocks.push(
+                // biome-ignore lint/performance/noImgElement: remote object-storage asset behind an auth-gated route, not a bundled static asset next/image can optimize
+                <img
+                    key={`img${b++}`}
+                    src={img[2]}
+                    alt={img[1] || "summary graphic"}
+                    className="my-3 max-w-full rounded-lg border border-border"
+                    loading="lazy"
+                />,
+            );
+            continue;
+        }
+
+        if (HR_RE.test(line)) {
+            flushAll();
+            blocks.push(<hr key={`hr${b++}`} className="my-4 border-border" />);
+            continue;
+        }
+
+        const h = line.match(HEADING_RE);
+        if (h) {
+            flushAll();
+            const level = Math.min(h[1].length, 6);
+            const key = `h${b++}`;
+            const inner = renderInline(h[2], key);
+            const cls: Record<number, string> = {
+                1: "text-xl font-bold mt-4 mb-2",
+                2: "text-lg font-semibold mt-4 mb-2",
+                3: "text-base font-semibold mt-3 mb-1",
+                4: "text-sm font-semibold mt-2 mb-1",
+                5: "text-sm font-medium mt-2 mb-1",
+                6: "text-xs font-medium uppercase tracking-wide mt-2 mb-1",
+            };
+            const c = cls[level];
+            blocks.push(
+                level === 1 ? (
+                    <h1 key={key} className={c}>
+                        {inner}
+                    </h1>
+                ) : level === 2 ? (
+                    <h2 key={key} className={c}>
+                        {inner}
+                    </h2>
+                ) : level === 3 ? (
+                    <h3 key={key} className={c}>
+                        {inner}
+                    </h3>
+                ) : level === 4 ? (
+                    <h4 key={key} className={c}>
+                        {inner}
+                    </h4>
+                ) : level === 5 ? (
+                    <h5 key={key} className={c}>
+                        {inner}
+                    </h5>
+                ) : (
+                    <h6 key={key} className={c}>
+                        {inner}
+                    </h6>
+                ),
+            );
+            continue;
+        }
+
+        const q = line.match(QUOTE_RE);
+        if (q) {
+            flushPara();
+            flushList();
+            quote.push(q[1]);
+            continue;
+        }
+        flushQuote();
+
+        const chk = line.match(CHECK_RE);
+        if (chk) {
+            flushPara();
+            if (!list || list.ordered) {
+                flushList();
+                list = { ordered: false, items: [] };
+            }
+            list.items.push({
+                text: chk[2],
+                check: chk[1].toLowerCase() === "x",
+            });
+            continue;
+        }
+        const bul = line.match(BULLET_RE);
+        if (bul) {
+            flushPara();
+            if (!list || list.ordered) {
+                flushList();
+                list = { ordered: false, items: [] };
+            }
+            list.items.push({ text: bul[1] });
+            continue;
+        }
+        const ord = line.match(ORDERED_RE);
+        if (ord) {
+            flushPara();
+            if (!list || !list.ordered) {
+                flushList();
+                list = { ordered: true, items: [] };
+            }
+            list.items.push({ text: ord[1] });
+            continue;
+        }
+
+        flushList();
+        para.push(line.trim());
+    }
+    flushAll();
+
+    return <div className={className}>{blocks}</div>;
+}
+
+const SPEAKER_RE = /^(Speaker\s+\w+|[A-Z][\w .'-]{0,40}):\s*(.*)$/;
+
+const SPEAKER_COLORS = [
+    "text-accent-cyan",
+    "text-emerald-400",
+    "text-amber-400",
+    "text-violet-400",
+    "text-rose-400",
+    "text-sky-400",
+];
+
+/**
+ * Render a diarized transcript as one block per speaker turn, colouring
+ * each speaker label consistently in order of first appearance.
+ *
+ * Plaud transcripts arrive as `SPEAKER_00: ...` / `Speaker 1: ...` lines,
+ * one turn per line. A line with no recognised label is appended to the
+ * preceding unlabelled turn. When no line carries a label at all (a plain
+ * Whisper transcript, for example) the whole text is rendered as
+ * pre-wrapped plain text, which is the previous behaviour.
+ */
+export function SpeakerTranscript({
+    text,
+    className,
+}: {
+    text: string;
+    className?: string;
+}): JSX.Element {
+    const lines = text
+        .replace(/\r\n/g, "\n")
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+
+    const turns: { speaker: string | null; text: string }[] = [];
+    for (const line of lines) {
+        const m = line.match(SPEAKER_RE);
+        if (m) turns.push({ speaker: m[1], text: m[2] });
+        else if (turns.length && turns[turns.length - 1].speaker === null)
+            turns[turns.length - 1].text += ` ${line}`;
+        else turns.push({ speaker: null, text: line });
+    }
+
+    const hasSpeakers = turns.some((t) => t.speaker !== null);
+    if (!hasSpeakers) {
+        return (
+            <p
+                className={`whitespace-pre-wrap leading-relaxed ${className ?? ""}`}
+            >
+                {text}
+            </p>
+        );
+    }
+
+    const order: string[] = [];
+    const colorFor = (speaker: string) => {
+        let idx = order.indexOf(speaker);
+        if (idx === -1) {
+            order.push(speaker);
+            idx = order.length - 1;
+        }
+        return SPEAKER_COLORS[idx % SPEAKER_COLORS.length];
+    };
+
+    return (
+        <div className={`space-y-3 ${className ?? ""}`}>
+            {turns.map((t, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: turns are reparsed from the transcript on every render and never reordered
+                <div key={`turn-${i}`} className="leading-relaxed">
+                    {t.speaker && (
+                        <span
+                            className={`font-semibold ${colorFor(t.speaker)} mr-2`}
+                        >
+                            {t.speaker}:
+                        </span>
+                    )}
+                    <span>{t.text}</span>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/recordings/rich-content.tsx
+++ b/src/components/recordings/rich-content.tsx
@@ -39,7 +39,14 @@ function renderInline(text: string, keyPrefix: string): ReactNode[] {
         else if (m[9]) nodes.push(<em key={k}>{m[10]}</em>);
         else if (m[11]) {
             const href = m[13];
-            const safe = href.startsWith("https://") || href.startsWith("/");
+            // Same-origin paths and https only. A leading "//" (or "/\") is
+            // protocol-relative and resolves to an EXTERNAL host, so it must not
+            // pass the "/" check.
+            const safe =
+                href.startsWith("https://") ||
+                (href.startsWith("/") &&
+                    !href.startsWith("//") &&
+                    !href.startsWith("/\\"));
             nodes.push(
                 safe ? (
                     <a
@@ -308,7 +315,12 @@ export function RichMarkdown({
     return <div className={className}>{blocks}</div>;
 }
 
-const SPEAKER_RE = /^(Speaker\s+\w+|[A-Z][\w .'-]{0,40}):\s*(.*)$/;
+// Only the diarization label formats this app actually emits — `SPEAKER_00`
+// (WhisperX), `Speaker 1` (Plaud), and the `UNKNOWN` fallback. A generic
+// `Capitalized:` pattern would misread an ordinary transcript line such as
+// `Question: ...` or `Action item: ...` as a speaker turn and wrongly switch a
+// non-diarized transcript out of its plain-text fallback.
+const SPEAKER_RE = /^(SPEAKER_\w+|Speaker\s+\w+|UNKNOWN):\s*(.*)$/;
 
 const SPEAKER_COLORS = [
     "text-accent-cyan",

--- a/src/components/recordings/rich-content.tsx
+++ b/src/components/recordings/rich-content.tsx
@@ -112,28 +112,45 @@ export function RichMarkdown({
     const flushList = () => {
         if (list) {
             const key = `l${b++}`;
-            const items = list.items.map((it, idx) => (
-                <li
-                    // biome-ignore lint/suspicious/noArrayIndexKey: parsed output is rebuilt from scratch on every render and never reordered
-                    key={`${key}-${idx}`}
-                    className="leading-relaxed flex gap-2 items-start"
-                >
-                    {it.check !== undefined && (
+            const ordered = list.ordered;
+            const items = list.items.map((it, idx) => {
+                // An ordered list keeps its native list-decimal marker, so it must NOT
+                // become a flex row and must not get a bullet injected - either would
+                // suppress the number. Only unordered rows use the flex + marker layout.
+                const marker =
+                    it.check !== undefined ? (
                         <input
                             type="checkbox"
                             checked={it.check}
                             readOnly
                             className="mt-1.5 shrink-0 accent-accent-cyan"
                         />
-                    )}
-                    {it.check === undefined && (
+                    ) : ordered ? null : (
                         <span className="mt-1.5 size-1.5 rounded-full bg-accent-cyan shrink-0" />
-                    )}
-                    <span>{renderInline(it.text, `${key}-${idx}`)}</span>
-                </li>
-            ));
+                    );
+                return (
+                    <li
+                        // biome-ignore lint/suspicious/noArrayIndexKey: parsed output is rebuilt from scratch on every render and never reordered
+                        key={`${key}-${idx}`}
+                        className={
+                            marker
+                                ? "leading-relaxed flex gap-2 items-start"
+                                : "leading-relaxed"
+                        }
+                    >
+                        {marker}
+                        {marker ? (
+                            <span>
+                                {renderInline(it.text, `${key}-${idx}`)}
+                            </span>
+                        ) : (
+                            renderInline(it.text, `${key}-${idx}`)
+                        )}
+                    </li>
+                );
+            });
             blocks.push(
-                list.ordered ? (
+                ordered ? (
                     <ol key={key} className="my-2 space-y-1 list-decimal pl-5">
                         {items}
                     </ol>

--- a/src/tests/regressions/265-rich-content.test.ts
+++ b/src/tests/regressions/265-rich-content.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Regression for #265: Plaud markdown summaries and SPEAKER-labeled
+ * transcript turns render as React trees in the transcription panel.
+ * Non-diarized text stays pre-wrapped; href/src stay on the allowlist.
+ */
+
+// @vitest-environment jsdom
+
+import { render } from "@testing-library/react";
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+import {
+    RichMarkdown,
+    SpeakerTranscript,
+} from "@/components/recordings/rich-content";
+
+describe("RichMarkdown (#265)", () => {
+    it("renders Plaud headings, emphasis, lists, quotes, and rules", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: [
+                    "# Meeting Summary",
+                    "",
+                    "This is **bold** and *italic* and ~~old~~ and `code`.",
+                    "",
+                    "- first",
+                    "- second",
+                    "",
+                    "1. alpha",
+                    "2. beta",
+                    "",
+                    "- [x] done",
+                    "- [ ] later",
+                    "",
+                    "> quoted",
+                    "",
+                    "---",
+                ].join("\n"),
+            }),
+        );
+
+        expect(container.querySelector("h1")?.textContent).toBe(
+            "Meeting Summary",
+        );
+        expect(container.querySelector("strong")?.textContent).toBe("bold");
+        expect(container.querySelector("em")?.textContent).toBe("italic");
+        expect(container.querySelector("del")?.textContent).toBe("old");
+        expect(container.querySelector("code")?.textContent).toBe("code");
+        expect(
+            [...container.querySelectorAll("ul > li")].map((li) =>
+                li.textContent?.trim(),
+            ),
+        ).toEqual(["first", "second", "done", "later"]);
+        const olItems = [...container.querySelectorAll("ol > li")];
+        expect(olItems.map((li) => li.textContent?.trim())).toEqual([
+            "alpha",
+            "beta",
+        ]);
+        expect(container.querySelector("ol")?.className).toContain(
+            "list-decimal",
+        );
+        for (const li of olItems) {
+            expect(li.className).not.toContain("flex");
+        }
+        expect(
+            container.querySelectorAll('input[type="checkbox"]'),
+        ).toHaveLength(2);
+        expect(
+            (
+                container.querySelector(
+                    'input[type="checkbox"]',
+                ) as HTMLInputElement
+            ).checked,
+        ).toBe(true);
+        expect(container.querySelector("blockquote")?.textContent).toBe(
+            "quoted",
+        );
+        expect(container.querySelector("hr")).not.toBeNull();
+    });
+
+    it("allowlists https and same-origin hrefs and rejects the rest", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: [
+                    "[ok](https://example.com/a)",
+                    "[path](/settings)",
+                    "[proto](//evil.example/x)",
+                    "[slash](/\\\\evil.example/x)",
+                    "[js](javascript:alert(1))",
+                    "[data](data:text/html,hi)",
+                    "[http](http://example.com/a)",
+                ].join("\n"),
+            }),
+        );
+
+        const hrefs = [...container.querySelectorAll("a")].map((a) =>
+            a.getAttribute("href"),
+        );
+        expect(hrefs).toEqual(["https://example.com/a", "/settings"]);
+        expect(container.textContent).toContain("proto");
+        expect(container.textContent).toContain("js");
+        expect(container.textContent).toContain("data");
+        expect(container.textContent).toContain("http");
+    });
+
+    it("allowlists image srcs and leaves unsafe images as text", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: [
+                    "![safe](https://cdn.example/img.png)",
+                    "![asset](/api/plaud-assets/x.png)",
+                    "![js](javascript:alert(1))",
+                    "![data](data:image/png;base64,aaaa)",
+                    "![proto](//evil.example/x.png)",
+                ].join("\n"),
+            }),
+        );
+
+        const srcs = [...container.querySelectorAll("img")].map((img) =>
+            img.getAttribute("src"),
+        );
+        expect(srcs).toEqual([
+            "https://cdn.example/img.png",
+            "/api/plaud-assets/x.png",
+        ]);
+        const hrefs = [...container.querySelectorAll("a")].map((a) =>
+            a.getAttribute("href"),
+        );
+        expect(hrefs).toEqual([]);
+        expect(srcs.some((src) => src?.startsWith("javascript:"))).toBe(false);
+        expect(srcs.some((src) => src?.startsWith("data:"))).toBe(false);
+        expect(srcs.some((src) => src?.startsWith("//"))).toBe(false);
+    });
+
+    it("escapes HTML instead of injecting it", () => {
+        const { container } = render(
+            createElement(RichMarkdown, {
+                content: '<script>alert("xss")</script>',
+            }),
+        );
+        expect(container.querySelector("script")).toBeNull();
+        expect(container.innerHTML).not.toContain("dangerouslySetInnerHTML");
+        expect(container.textContent).toContain(
+            '<script>alert("xss")</script>',
+        );
+    });
+});
+
+describe("SpeakerTranscript (#265)", () => {
+    it("groups SPEAKER, Speaker n, and UNKNOWN turns", () => {
+        const { container } = render(
+            createElement(SpeakerTranscript, {
+                text: [
+                    "SPEAKER_00: hello",
+                    "Speaker 1: there",
+                    "UNKNOWN: who",
+                    "SPEAKER_00: again",
+                ].join("\n"),
+            }),
+        );
+
+        const turns = [...container.querySelectorAll(":scope > div > div")];
+        expect(turns).toHaveLength(4);
+        expect(turns[0].querySelector("span")?.textContent).toBe("SPEAKER_00:");
+        expect(turns[1].querySelector("span")?.textContent).toBe("Speaker 1:");
+        expect(turns[2].querySelector("span")?.textContent).toBe("UNKNOWN:");
+        expect(turns[0].textContent).toContain("hello");
+        expect(turns[3].textContent).toContain("again");
+        expect(turns[0].querySelector("span")?.className).toContain(
+            "text-accent-cyan",
+        );
+        expect(turns[3].querySelector("span")?.className).toContain(
+            "text-accent-cyan",
+        );
+        expect(turns[1].querySelector("span")?.className).toContain(
+            "text-emerald-400",
+        );
+    });
+
+    it("keeps non-diarized transcripts pre-wrapped", () => {
+        const text = "Question: what now?\nAction item: ship it\nJust prose.";
+        const { container } = render(
+            createElement(SpeakerTranscript, { text }),
+        );
+        const p = container.querySelector("p");
+        expect(p).not.toBeNull();
+        expect(p?.className).toContain("whitespace-pre-wrap");
+        expect(p?.textContent).toBe(text);
+        expect(container.querySelectorAll(":scope > div > div")).toHaveLength(
+            0,
+        );
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Origin-owned replacement for #265 so required CI can run. Renders Plaud markdown summaries and labeled diarized transcripts as structured, escaped React content.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Relates to #230, #204, and #265.

## Changes Made

- Render Plaud’s supported markdown subset without raw HTML or new dependencies.
- Group recognized speaker labels into consistent speaker turns.
- Preserve plain-text fallback for non-diarized transcripts.
- Restrict links and images to approved URL forms.

## Testing

- Existing regression coverage: `src/tests/regressions/265-rich-content.test.ts`
- Prior contributor validation: format/lint, type-check, test, and build.

## Checklist

- [x] My code follows the style guidelines of this project (`pnpm format-and-lint`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove the feature works
- [x] Type checking passes (`pnpm type-check`)
- [x] Any dependent changes have been merged and published

## Database Changes

None.

## Breaking Changes

None.

## Additional Notes

#265’s external-fork Actions runs require manual approval and cannot satisfy the four required checks through the available API. This branch is the same reviewed render-only change rebased onto current main.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d1f9133-dd58-52a9-8d67-2a3ce1af5798?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d1f9133-dd58-52a9-8d67-2a3ce1af5798&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #265 by rendering Plaud summaries as markdown and diarized transcripts as speaker turns in the transcription panel. Both were previously shown as raw text; they now use readable React elements without raw HTML or new dependencies.

**New Features**
- `RichMarkdown` supports Plaud headings, emphasis, lists, quotes, rules, links, and images.
- `SpeakerTranscript` groups `SPEAKER_00`, `Speaker 1`, `UNKNOWN`, and timestamped OpenAI speaker headers into consistently colored turns.
- Non-diarized transcripts retain their original pre-wrapped plain-text rendering.
- Links allow only `https://` and same-origin paths; images allow Plaud API URLs and `/api/plaud-assets/`, while rejected URLs remain plain text.

<sup>Written for commit d819b9aef2811ab6f55b534aa10bb93177bf82eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/riffado/riffado/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

